### PR TITLE
Angle snapping

### DIFF
--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -357,12 +357,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "مستطيل"
-  :help [:div "اضغط %1 لقفل النسب."]
   :create-rectangle "إنشاء مستطيل"}
 
  :renderer.tool.impl.element.svg
  {:label "SVG"
-  :help [:div "اضغط %1 لقفل النسب."]
   :create-svg "إنشاء svg"}
 
  :renderer.tool.impl.extension.blob
@@ -590,8 +588,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "قطع ناقص"
-  :create-ellipse "إنشاء قطع ناقص"
-  :help [:div "اضغط %1 لقفل النسب."]}
+  :create-ellipse "إنشاء قطع ناقص"}
 
  :renderer.tool.impl.element.line
  {:label "خط"

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -387,12 +387,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Rechteck"
-  :help [:div "Halten Sie %1, um die Proportionen zu sperren."]
   :create-rectangle "Rechteck erstellen"}
 
  :renderer.tool.impl.element.svg
  {:label "SVG"
-  :help [:div "Halten Sie %1, um die Proportionen zu sperren."]
   :create-svg "SVG erstellen"}
 
  :renderer.tool.impl.extension.blob
@@ -635,8 +633,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Ellipse"
-  :create-ellipse "Ellipse erstellen"
-  :help [:div "Halten Sie %1, um die Proportionen zu sperren."]}
+  :create-ellipse "Ellipse erstellen"}
 
  :renderer.tool.impl.element.line
  {:label "Linie"

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -390,12 +390,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Ορθογώνιο"
-  :help [:div "Κρατήστε %1 για να κλειδώσετε τις αναλογίες."]
   :create-rectangle "Δημιουργία ορθ. παραλληλόγραμου"}
 
  :renderer.tool.impl.element.svg
  {:label "Svg"
-  :help [:div "Κρατήστε %1 για να κλειδώσετε τις αναλογίες."]
   :create-svg "Δημιουργία svg"}
 
  :renderer.tool.impl.extension.blob
@@ -639,8 +637,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Έλλειψη"
-  :create-ellipse "Δημιουργία έλλειψης"
-  :help [:div "Κρατήστε %1 για να κλειδώσετε τις αναλογίες."]}
+  :create-ellipse "Δημιουργία έλλειψης"}
 
  :renderer.tool.impl.element.line
  {:label "Γραμμή"

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -386,12 +386,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Rectangle"
-  :help [:div "Hold %1 to lock proportions."]
   :create-rectangle "Create rectangle"}
 
  :renderer.tool.impl.element.svg
  {:label "Svg"
-  :help [:div "Hold %1 to lock proportions."]
   :create-svg "Create svg"}
 
  :renderer.tool.impl.extension.blob
@@ -603,8 +601,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Ellipse"
-  :create-ellipse "Create ellipse"
-  :help [:div "Hold %1 to lock proportions."]}
+  :create-ellipse "Create ellipse"}
 
  :renderer.tool.impl.element.line
  {:label "Line"

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -375,12 +375,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Rectángulo"
-  :help [:div "Mantenga %1 para bloquear proporciones."]
   :create-rectangle "Crear rectángulo"}
 
  :renderer.tool.impl.element.svg
  {:label "SVG"
-  :help [:div "Mantenga %1 para bloquear proporciones."]
   :create-svg "Crear SVG"}
 
  :renderer.tool.impl.extension.blob
@@ -619,8 +617,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Elipse"
-  :create-ellipse "Crear elipse"
-  :help [:div "Mantenga %1 para bloquear proporciones."]}
+  :create-ellipse "Crear elipse"}
 
  :renderer.tool.impl.element.line
  {:label "Línea"

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -380,12 +380,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Rectangle"
-  :help [:div "Maintenez %1 pour verrouiller les proportions."]
   :create-rectangle "Créer un rectangle"}
 
  :renderer.tool.impl.element.svg
  {:label "SVG"
-  :help [:div "Maintenez %1 pour verrouiller les proportions."]
   :create-svg "Créer un SVG"}
 
  :renderer.tool.impl.extension.blob
@@ -626,8 +624,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Ellipse"
-  :create-ellipse "Créer une ellipse"
-  :help [:div "Maintenez %1 pour verrouiller les proportions."]}
+  :create-ellipse "Créer une ellipse"}
 
  :renderer.tool.impl.element.line
  {:label "Ligne"

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -403,12 +403,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Rettangolo"
-  :help [:div "Tieni premuto %1 per bloccare le proporzioni."]
   :create-rectangle "Crea rettangolo"}
 
  :renderer.tool.impl.element.svg
  {:label "Svg"
-  :help [:div "Tieni premuto %1 per bloccare le proporzioni."]
   :create-svg "Crea svg"}
 
  :renderer.tool.impl.extension.blob
@@ -631,8 +629,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Ellisse"
-  :create-ellipse "Crea ellisse"
-  :help [:div "Tieni premuto %1 per bloccare le proporzioni."]}
+  :create-ellipse "Crea ellisse"}
 
  :renderer.tool.impl.element.line
  {:label "Linea"

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -342,12 +342,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "矩形"
-  :help [:div "%1を押しながら比率をロック。"]
   :create-rectangle "矩形を作成"}
 
  :renderer.tool.impl.element.svg
  {:label "SVG"
-  :help [:div "%1を押しながら比率をロック。"]
   :create-svg "SVGを作成"}
 
  :renderer.tool.impl.extension.blob
@@ -575,8 +573,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "楕円"
-  :create-ellipse "楕円を作成"
-  :help [:div "%1を押しながら比率をロック。"]}
+  :create-ellipse "楕円を作成"}
 
  :renderer.tool.impl.element.line
  {:label "線"

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -356,12 +356,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "사각형"
-  :help [:div "%1을 누르면 비율을 고정합니다."]
   :create-rectangle "사각형 생성"}
 
  :renderer.tool.impl.element.svg
  {:label "SVG"
-  :help [:div "%1을 누르면 비율을 고정합니다."]
   :create-svg "SVG 생성"}
 
  :renderer.tool.impl.extension.blob
@@ -571,8 +569,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "타원"
-  :create-ellipse "타원 생성"
-  :help [:div "%1을 누르면 비율을 고정합니다."]}
+  :create-ellipse "타원 생성"}
 
  :renderer.tool.impl.element.line
  {:label "선"

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -405,12 +405,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Rechthoek"
-  :help [:div "Houd %1 ingedrukt om verhoudingen te vergrendelen."]
   :create-rectangle "Rechthoek maken"}
 
  :renderer.tool.impl.element.svg
  {:label "Svg"
-  :help [:div "Houd %1 ingedrukt om verhoudingen te vergrendelen."]
   :create-svg "Svg maken"}
 
  :renderer.tool.impl.extension.blob
@@ -632,8 +630,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Ellips"
-  :create-ellipse "Ellips maken"
-  :help [:div "Houd %1 ingedrukt om verhoudingen te vergrendelen."]}
+  :create-ellipse "Ellips maken"}
 
  :renderer.tool.impl.element.line
  {:label "Lijn"

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -372,12 +372,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Retângulo"
-  :help [:div "Mantenha %1 para bloquear proporções."]
   :create-rectangle "Criar retângulo"}
 
  :renderer.tool.impl.element.svg
  {:label "SVG"
-  :help [:div "Mantenha %1 para bloquear proporções."]
   :create-svg "Criar SVG"}
 
  :renderer.tool.impl.extension.blob
@@ -614,8 +612,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Elipse"
-  :create-ellipse "Criar elipse"
-  :help [:div "Mantenha %1 para bloquear proporções."]}
+  :create-ellipse "Criar elipse"}
 
  :renderer.tool.impl.element.line
  {:label "Linha"

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -369,12 +369,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Прямоугольник"
-  :help [:div "Удерживайте %1 для блокировки пропорций."]
   :create-rectangle "Создать прямоугольник"}
 
  :renderer.tool.impl.element.svg
  {:label "SVG"
-  :help [:div "Удерживайте %1 для блокировки пропорций."]
   :create-svg "Создать SVG"}
 
  :renderer.tool.impl.extension.blob
@@ -615,8 +613,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Эллипс"
-  :create-ellipse "Создать эллипс"
-  :help [:div "Удерживайте %1 для блокировки пропорций."]}
+  :create-ellipse "Создать эллипс"}
 
  :renderer.tool.impl.element.line
  {:label "Линия"

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -394,12 +394,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Rektangel"
-  :help [:div "Håll %1 för att låsa proportioner."]
   :create-rectangle "Skapa rektangel"}
 
  :renderer.tool.impl.element.svg
  {:label "Svg"
-  :help [:div "Håll %1 för att låsa proportioner."]
   :create-svg "Skapa svg"}
 
  :renderer.tool.impl.extension.blob
@@ -617,8 +615,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Ellips"
-  :create-ellipse "Skapa ellips"
-  :help [:div "Håll %1 för att låsa proportioner."]}
+  :create-ellipse "Skapa ellips"}
 
  :renderer.tool.impl.element.line
  {:label "Linje"

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -387,12 +387,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "Dikdörtgen"
-  :help [:div "Oranları kilitlemek için %1 tuşunu basılı tutun."]
   :create-rectangle "Dikdörtgen oluştur"}
 
  :renderer.tool.impl.element.svg
  {:label "SVG"
-  :help [:div "Oranları kilitlemek için %1 tuşunu basılı tutun."]
   :create-svg "SVG oluştur"}
 
  :renderer.tool.impl.extension.blob
@@ -610,8 +608,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "Elips"
-  :create-ellipse "Elips oluştur"
-  :help [:div "Oranları kilitlemek için %1 tuşunu basılı tutun."]}
+  :create-ellipse "Elips oluştur"}
 
  :renderer.tool.impl.element.line
  {:label "Çizgi"

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -312,12 +312,10 @@
 
  :renderer.tool.impl.element.rect
  {:label "矩形"
-  :help [:div "按住 %1 锁定比例。"]
   :create-rectangle "创建矩形"}
 
  :renderer.tool.impl.element.svg
  {:label "SVG"
-  :help [:div "按住 %1 锁定比例。"]
   :create-svg "创建 SVG"}
 
  :renderer.tool.impl.extension.blob
@@ -536,8 +534,7 @@
 
  :renderer.tool.impl.element.ellipse
  {:label "椭圆"
-  :create-ellipse "创建椭圆"
-  :help [:div "按住 %1 锁定比例。"]}
+  :create-ellipse "创建椭圆"}
 
  :renderer.tool.impl.element.line
  {:label "线条"

--- a/src/renderer/element/impl/shape/path.cljs
+++ b/src/renderer/element/impl/shape/path.cljs
@@ -208,15 +208,32 @@
       (-> (translate-seg-point index :end-control-point delta)
           (translate-seg-point (inc index) :start-control-point delta)))))
 
+(defn snap-control-point-to-angle
+  [segments index point-type offset]
+  (let [endpoints (acc-endpoints segments)
+        anchor (if (= point-type :start-control-point)
+                 (get endpoints (dec index))
+                 (get endpoints index))
+        cp-pos (->px-point (get segments index) point-type)
+        new-cp-pos (matrix/add cp-pos offset)
+        snapped (input.handlers/snap-angle anchor new-cp-pos)]
+    (matrix/sub snapped cp-pos)))
+
 (defmethod element.hierarchy/edit :path
   [el offset handle lock?]
-  (let [offset (cond-> offset lock? input.handlers/lock-direction)
-        index (js/parseInt (namespace handle))
-        point-type (keyword (name handle))]
+  (let [point-type (keyword (name handle))
+        index (js/parseInt (namespace handle))]
     (update-in el [:attrs :d]
-               #(->> (utils.path/string->segments %)
-                     (translate-point index point-type offset)
-                     (utils.path/segments->string)))))
+               #(let [segments (utils.path/string->segments %)
+                      snap-fn (if (= point-type :end-point)
+                                input.handlers/lock-direction
+                                (partial snap-control-point-to-angle
+                                         segments index
+                                         point-type))
+                      offset (cond->> offset lock? snap-fn)]
+                  (->> segments
+                       (translate-point index point-type offset)
+                       (utils.path/segments->string))))))
 
 (defmethod element.hierarchy/path :path
   [el]

--- a/src/renderer/input/handlers.cljs
+++ b/src/renderer/input/handlers.cljs
@@ -13,7 +13,8 @@
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
-   [renderer.tool.impl.base.pan :as-alias tool.impl.base.pan]))
+   [renderer.tool.impl.base.pan :as-alias tool.impl.base.pan]
+   [renderer.utils.math :as utils.math]))
 
 (m/=> adjusted-pointer-pos [:-> App Vec2 Vec2])
 (defn adjusted-pointer-pos
@@ -30,6 +31,17 @@
   (if (> (abs x) (abs y))
     [x 0]
     [0 y]))
+
+(m/=> snap-angle [:-> Vec2 Vec2 Vec2])
+(defn snap-angle
+  "Snaps the end position to the nearest 15 degree angle."
+  [start end]
+  (let [degrees (utils.math/angle start end)
+        snapped (* (Math/round (/ degrees 15)) 15)
+        r (matrix/distance start end)
+        [x1 y1] start]
+    [(+ x1 (utils.math/angle-dx snapped r))
+     (+ y1 (utils.math/angle-dy snapped r))]))
 
 (m/=> on-pinch [:-> App PointerEvent App])
 (defn on-pinch

--- a/src/renderer/input/handlers.cljs
+++ b/src/renderer/input/handlers.cljs
@@ -120,8 +120,12 @@
 (defn on-pointer-move
   [db e]
   (let [{:keys [pointer-offset drag-pointer active-pointers]} db
-        {:keys [pointer-pos pointer-id]} e]
-    (if (and (tool.handlers/multi-touch? db) (not drag-pointer))
+        {:keys [pointer-pos pointer-id]} e
+        multi-touch? (tool.handlers/multi-touch? db)
+        pointer-pos (cond->> pointer-pos
+                      (or (:ctrl-key e) multi-touch?)
+                      (snap-angle pointer-offset))]
+    (if (and multi-touch? (not drag-pointer))
       (on-pinch db e)
       (cond-> (if (and pointer-offset
                        (contains? active-pointers pointer-id)

--- a/src/renderer/tool/impl/element/ellipse.cljs
+++ b/src/renderer/tool/impl/element/ellipse.cljs
@@ -7,32 +7,25 @@
    [renderer.element.handlers :as element.handlers]
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
-   [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
    [renderer.tool.subs :as-alias tool.subs]
-   [renderer.utils.length :as utils.length]
-   [renderer.views :as views]))
+   [renderer.utils.length :as utils.length]))
 
 (hierarchy/derive! ::ellipse ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/help [::ellipse :create]
-  []
-  (i18n.views/t [::help [:div "Hold %1 to lock proportions."]]
-                [[views/kbd "Ctrl"]]))
-
 (defn attributes
-  [db lock-ratio]
+  [db]
   (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
         [x y] (tool.handlers/snapped-position db)
-        rx (abs (- x offset-x))
-        ry (abs (- y offset-y))]
-    {:rx (utils.length/->fixed (cond-> rx lock-ratio (min ry)))
-     :ry (utils.length/->fixed (cond-> ry lock-ratio (min rx)))}))
+        [rx ry] (->> [(abs (- x offset-x)) (abs (- y offset-y))]
+                     (mapv utils.length/->fixed))]
+    {:rx rx
+     :ry ry}))
 
 (defmethod tool.hierarchy/on-drag-start [::ellipse :idle]
-  [db e]
+  [db _e]
   (let [[x y] (tool.handlers/snapped-position db)
         fill (document.handlers/attr db :fill)
         stroke (document.handlers/attr db :stroke)]
@@ -40,16 +33,15 @@
         (tool.handlers/set-state :create)
         (element.handlers/add {:type :element
                                :tag :ellipse
-                               :attrs (merge (attributes db (:ctrl-key e))
+                               :attrs (merge (attributes db)
                                              {:cx x
                                               :cy y
                                               :fill fill
                                               :stroke stroke})}))))
 
 (defmethod tool.hierarchy/on-drag [::ellipse :create]
-  [db e]
-  (let [lock-ratio (or (:ctrl-key e) (tool.handlers/multi-touch? db))
-        attrs (attributes db lock-ratio)
+  [db _e]
+  (let [attrs (attributes db)
         assoc-attr (fn [el [k v]] (assoc-in el [:attrs k] (str v)))]
     (element.handlers/update-selected db #(reduce assoc-attr % attrs))))
 

--- a/src/renderer/tool/impl/element/rect.cljs
+++ b/src/renderer/tool/impl/element/rect.cljs
@@ -7,51 +7,40 @@
    [renderer.element.handlers :as element.handlers]
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
-   [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
    [renderer.tool.subs :as-alias tool.subs]
    [renderer.utils.key :as utils.key]
-   [renderer.utils.length :as utils.length]
-   [renderer.views :as views]))
+   [renderer.utils.length :as utils.length]))
 
 (hierarchy/derive! ::rect ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/help [::rect :create]
-  []
-  (i18n.views/t [::help [:div "Hold %1 to lock proportions."]]
-                [[views/kbd "Ctrl"]]))
-
 (defn attributes
-  [db lock-ratio]
+  [db]
   (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
         [x y] (tool.handlers/snapped-position db)
-        width (abs (- x offset-x))
-        height (abs (- y offset-y))
-        width (cond-> width lock-ratio (min height))
-        height (cond-> height lock-ratio (min width))]
+        [width height] (mapv abs [(- x offset-x) (- y offset-y)])]
     {:x (utils.length/->fixed (cond-> offset-x (< x offset-x) (- width)))
      :y (utils.length/->fixed (cond-> offset-y (< y offset-y) (- height)))
      :width (utils.length/->fixed width)
      :height (utils.length/->fixed height)}))
 
 (defmethod tool.hierarchy/on-drag-start [::rect :idle]
-  [db e]
+  [db _e]
   (let [fill (document.handlers/attr db :fill)
         stroke (document.handlers/attr db :stroke)]
     (-> db
         (tool.handlers/set-state :create)
         (element.handlers/add {:type :element
                                :tag :rect
-                               :attrs (merge (attributes db (:ctrl-key e))
+                               :attrs (merge (attributes db)
                                              {:fill fill
                                               :stroke stroke})}))))
 
 (defmethod tool.hierarchy/on-drag [::rect :create]
-  [db e]
-  (let [lock-ratio (or (:ctrl-key e) (tool.handlers/multi-touch? db))
-        attrs (attributes db lock-ratio)
+  [db _e]
+  (let [attrs (attributes db)
         assoc-attr (fn [el [k v]] (assoc-in el [:attrs k] (str v)))
         [min-x min-y] (element.handlers/parent-offset db)]
     (-> db

--- a/src/renderer/tool/impl/element/svg.cljs
+++ b/src/renderer/tool/impl/element/svg.cljs
@@ -6,21 +6,14 @@
    [renderer.element.handlers :as element.handlers]
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
-   [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
    [renderer.tool.subs :as-alias tool.subs]
    [renderer.utils.key :as utils.key]
-   [renderer.utils.length :as utils.length]
-   [renderer.views :as views]))
+   [renderer.utils.length :as utils.length]))
 
 (hierarchy/derive! ::svg ::tool.hierarchy/element)
-
-(defmethod tool.hierarchy/help [::svg :create]
-  []
-  (i18n.views/t [::help [:div "Hold %1 to lock proportions."]]
-                [[views/kbd "Ctrl"]]))
 
 (defn attributes
   [db lock-ratio]

--- a/src/renderer/tool/impl/misc/measure.cljs
+++ b/src/renderer/tool/impl/misc/measure.cljs
@@ -9,6 +9,7 @@
    [renderer.element.handlers :as element.handlers]
    [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
+   [renderer.input.handlers :as input.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -16,7 +17,8 @@
    [renderer.utils.key :as utils.key]
    [renderer.utils.length :as utils.length]
    [renderer.utils.math :as utils.math]
-   [renderer.utils.svg :as utils.svg]))
+   [renderer.utils.svg :as utils.svg]
+   [renderer.views :as views]))
 
 (hierarchy/derive! ::measure ::tool.hierarchy/tool)
 
@@ -33,7 +35,10 @@
 
 (defmethod tool.hierarchy/help [::measure :create]
   []
-  (i18n.views/t [::release-to-finalize "Release to finalize the measurement."]))
+  [:<>
+   (i18n.views/t [::release-to-finalize "Release to finalize the measurement."])
+   (i18n.views/t [::snap-to-angle [:div "Hold %1 to snap to angle."]]
+                 [[views/kbd "Ctrl"]])])
 
 (defmethod tool.hierarchy/on-activate ::measure
   [db]
@@ -52,9 +57,11 @@
   (tool.handlers/set-state db :idle))
 
 (defmethod tool.hierarchy/on-drag [::measure :create]
-  [db _e]
+  [db e]
   (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
-        [x y] (tool.handlers/snapped-position db)
+        [x y] (cond->> (tool.handlers/snapped-position db)
+                (:ctrl-key e)
+                (input.handlers/snap-angle [offset-x offset-y]))
         [adjacent opposite] (matrix/sub [offset-x offset-y] [x y])
         hypotenuse (Math/hypot adjacent opposite)]
     (app.handlers/add-fx db [::set-measure-attrs {:x1 offset-x

--- a/src/renderer/tool/impl/misc/measure.cljs
+++ b/src/renderer/tool/impl/misc/measure.cljs
@@ -9,7 +9,6 @@
    [renderer.element.handlers :as element.handlers]
    [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
-   [renderer.input.handlers :as input.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -17,8 +16,7 @@
    [renderer.utils.key :as utils.key]
    [renderer.utils.length :as utils.length]
    [renderer.utils.math :as utils.math]
-   [renderer.utils.svg :as utils.svg]
-   [renderer.views :as views]))
+   [renderer.utils.svg :as utils.svg]))
 
 (hierarchy/derive! ::measure ::tool.hierarchy/tool)
 
@@ -35,10 +33,7 @@
 
 (defmethod tool.hierarchy/help [::measure :create]
   []
-  [:<>
-   (i18n.views/t [::release-to-finalize "Release to finalize the measurement."])
-   (i18n.views/t [::snap-to-angle [:div "Hold %1 to snap to angle."]]
-                 [[views/kbd "Ctrl"]])])
+  (i18n.views/t [::release-to-finalize "Release to finalize the measurement."]))
 
 (defmethod tool.hierarchy/on-activate ::measure
   [db]
@@ -57,17 +52,15 @@
   (tool.handlers/set-state db :idle))
 
 (defmethod tool.hierarchy/on-drag [::measure :create]
-  [db e]
-  (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
-        [x y] (cond->> (tool.handlers/snapped-position db)
-                (:ctrl-key e)
-                (input.handlers/snap-angle [offset-x offset-y]))
-        [adjacent opposite] (matrix/sub [offset-x offset-y] [x y])
+  [db _e]
+  (let [offset (tool.handlers/snapped-offset db)
+        position (tool.handlers/snapped-position db)
+        [adjacent opposite] (matrix/sub offset position)
         hypotenuse (Math/hypot adjacent opposite)]
-    (app.handlers/add-fx db [::set-measure-attrs {:x1 offset-x
-                                                  :y1 offset-y
-                                                  :x2 x
-                                                  :y2 y
+    (app.handlers/add-fx db [::set-measure-attrs {:x1 (first offset)
+                                                  :y1 (second offset)
+                                                  :x2 (first position)
+                                                  :y2 (second position)
                                                   :hypotenuse hypotenuse}])))
 
 (defmethod tool.hierarchy/render ::measure


### PR DESCRIPTION
This PR introduces angle snapping every 15 degrees (0, 15, 30, 45 ...90 etc) on Ctrl hold, while dragging. Snapping to angles when we drag path control points required special handling was also implemented. Holding Ctrl to lock shape proportions was removed, since it covered by this PR, that also supports more ratios (see video below).

https://github.com/user-attachments/assets/9fc33a82-de7d-448d-800e-f17a8fc0aaa3

