### PR TITLE
Refactor input module

### DIFF
--- a/src/renderer/app/subs.cljs
+++ b/src/renderer/app/subs.cljs
@@ -4,39 +4,6 @@
    [renderer.utils.platform :as utils.platform]))
 
 (rf/reg-sub
- ::active-pointers
- :-> :active-pointers)
-
-(rf/reg-sub
- ::pinch-distance
- :-> :pinch-distance)
-
-(rf/reg-sub
- ::pointer-pos
- :-> :pointer-pos)
-
-(rf/reg-sub
- ::adjusted-pointer-pos
- :-> :adjusted-pointer-pos)
-
-(rf/reg-sub
- ::pointer-offset
- :-> :pointer-offset)
-
-(rf/reg-sub
- ::drag-pointer
- :-> :drag-pointer)
-
-(rf/reg-sub
- ::drag?
- :<- [::drag-pointer]
- :-> boolean)
-
-(rf/reg-sub
- ::adjusted-pointer-offset
- :-> :adjusted-pointer-offset)
-
-(rf/reg-sub
  ::dom-rect
  :-> :dom-rect)
 

--- a/src/renderer/app/views.cljs
+++ b/src/renderer/app/views.cljs
@@ -18,6 +18,7 @@
    [renderer.home.views :as home.views]
    [renderer.i18n.subs :as-alias i18n.subs]
    [renderer.i18n.views :as i18n.views]
+   [renderer.input.subs :as-alias input.subs]
    [renderer.menubar.views :as menubar.views]
    [renderer.panel.subs :as-alias panel.subs]
    [renderer.panel.views :as panel.views]
@@ -56,13 +57,13 @@
 (defn debug-rows
   []
   (let [viewbox @(rf/subscribe [::frame.subs/viewbox])
-        active-pointers @(rf/subscribe [::app.subs/active-pointers])
-        pinch-distance @(rf/subscribe [::app.subs/pinch-distance])
-        pointer-pos @(rf/subscribe [::app.subs/pointer-pos])
-        adjusted-pos @(rf/subscribe [::app.subs/adjusted-pointer-pos])
-        pointer-offset @(rf/subscribe [::app.subs/pointer-offset])
-        adjusted-offset @(rf/subscribe [::app.subs/adjusted-pointer-offset])
-        drag? @(rf/subscribe [::tool.subs/drag?])
+        active-pointers @(rf/subscribe [::input.subs/active-pointers])
+        pinch-distance @(rf/subscribe [::input.subs/pinch-distance])
+        pointer-pos @(rf/subscribe [::input.subs/pointer-pos])
+        adjusted-pos @(rf/subscribe [::input.subs/adjusted-pointer-pos])
+        pointer-offset @(rf/subscribe [::input.subs/pointer-offset])
+        adjusted-offset @(rf/subscribe [::input.subs/adjusted-pointer-offset])
+        drag? @(rf/subscribe [::input.subs/drag?])
         pan @(rf/subscribe [::document.subs/pan])
         active-tool @(rf/subscribe [::tool.subs/active])
         cached-tool @(rf/subscribe [::tool.subs/cached])

--- a/src/renderer/input/core.cljs
+++ b/src/renderer/input/core.cljs
@@ -1,4 +1,5 @@
 (ns renderer.input.core
   (:require
    [renderer.input.effects]
-   [renderer.input.events]))
+   [renderer.input.events]
+   [renderer.input.subs]))

--- a/src/renderer/input/handlers.cljs
+++ b/src/renderer/input/handlers.cljs
@@ -3,26 +3,11 @@
    [clojure.core.matrix :as matrix]
    [malli.core :as m]
    [renderer.app.db :refer [App]]
-   [renderer.app.effects :as-alias app.effects]
-   [renderer.app.handlers :as app.handlers]
    [renderer.db :refer [Vec2]]
-   [renderer.effects :as-alias effects]
-   [renderer.frame.handlers :as frame.handlers]
-   [renderer.input.db :refer [PointerEvent KeyboardEvent WheelEvent DragEvent]]
-   [renderer.input.effects :as-alias input.effects]
+   [renderer.input.db :refer [DragEvent KeyboardEvent PointerEvent WheelEvent]]
+   [renderer.input.hierarchy :as input.hierarchy]
    [renderer.snap.handlers :as snap.handlers]
-   [renderer.tool.handlers :as tool.handlers]
-   [renderer.tool.hierarchy :as tool.hierarchy]
-   [renderer.tool.impl.base.pan :as-alias tool.impl.base.pan]
    [renderer.utils.math :as utils.math]))
-
-(m/=> adjusted-pos [:-> App Vec2 Vec2])
-(defn adjusted-pos
-  [db pos]
-  (let [{:keys [zoom pan]} (get-in db [:documents (:active-document db)])]
-    (-> pos
-        (matrix/div zoom)
-        (matrix/add pan))))
 
 (m/=> lock-direction [:-> Vec2 Vec2])
 (defn lock-direction
@@ -31,6 +16,14 @@
   (if (> (abs x) (abs y))
     [x 0]
     [0 y]))
+
+(m/=> adjusted-pos [:-> App Vec2 Vec2])
+(defn adjusted-pos
+  [db pos]
+  (let [{:keys [zoom pan]} (get-in db [:documents (:active-document db)])]
+    (-> pos
+        (matrix/div zoom)
+        (matrix/add pan))))
 
 (m/=> snap-angle [:-> Vec2 Vec2 Vec2])
 (defn snap-angle
@@ -43,280 +36,37 @@
     [(+ x1 (utils.math/angle-dx snapped r))
      (+ y1 (utils.math/angle-dy snapped r))]))
 
-(m/=> on-pinch [:-> App PointerEvent App])
-(defn on-pinch
-  [db e]
-  (let [{:keys [active-pointers pinch-distance pinch-midpoint]} db
-        {:keys [pointer-id]} e
-        active-pointers (assoc active-pointers pointer-id e)
-        [pos1 pos2] (->> (vals active-pointers)
-                         (take 2)
-                         (map :pointer-pos))
-        distance (matrix/distance pos1 pos2)
-        midpoint (-> (matrix/add pos1 pos2)
-                     (matrix/div 2))
-        adjusted-midpoint (adjusted-pos db midpoint)]
-    (cond-> db
-      :always
-      (assoc :active-pointers active-pointers
-             :pinch-distance distance
-             :pinch-midpoint midpoint)
+(defn multi-touch?
+  [db]
+  (> (count (:active-pointers db)) 1))
 
-      pinch-distance
-      (-> (frame.handlers/pan-by (matrix/sub pinch-midpoint midpoint))
-          (frame.handlers/zoom-at-position (/ distance pinch-distance)
-                                           adjusted-midpoint)))))
-
-(m/=> on-drag-start [:-> App PointerEvent App])
-(defn on-drag-start
-  [db {:keys [pointer-id]
-       :as e}]
+(m/=> clear-pointer-data [:-> App App])
+(defn clear-pointer-data
+  [db]
   (-> db
-      (assoc :drag-pointer pointer-id)
-      (tool.hierarchy/on-drag-start e)
-      (app.handlers/add-fx [::input.effects/set-pointer-capture pointer-id])))
-
-(m/=> on-drag-end [:-> App PointerEvent App])
-(defn on-drag-end
-  [db {:keys [pointer-id]
-       :as e}]
-  (-> db
-      (tool.hierarchy/on-drag-end e)
-      (tool.handlers/clear-pointer-data)
-      (app.handlers/add-fx [::input.effects/release-pointer-capture
-                            pointer-id])))
-
-(m/=> drag-pointer? [:-> App PointerEvent boolean?])
-(defn drag-pointer?
-  [db e]
-  (= (:drag-pointer db)
-     (:pointer-id e)))
-
-(m/=> on-drag [:-> App PointerEvent App])
-(defn on-drag
-  [db e]
-  (let [{:keys [pointer-offset tool dom-rect drag-pointer]} db
-        {:keys [pointer-pos]} e]
-    (cond-> db
-      (and (not= tool ::tool.impl.base.pan/pan)
-           (drag-pointer? db e))
-      (tool.handlers/pan-out-of-canvas dom-rect pointer-pos pointer-offset)
-
-      (not drag-pointer)
-      (on-drag-start e)
-
-      :always
-      (tool.hierarchy/on-drag e))))
-
-(m/=> significant-drag? [:-> App PointerEvent boolean?])
-(defn significant-drag?
-  [db e]
-  (let [{:keys [pointer-offset drag-threshold]} db
-        {:keys [pointer-pos]} e]
-    (> (matrix/distance pointer-offset pointer-pos)
-       drag-threshold)))
-
-(defn drag?
-  [db e]
-  (let [{:keys [pointer-offset active-pointers]} db
-        {:keys [pointer-id]} e]
-    (and pointer-offset
-         (contains? active-pointers pointer-id)
-         (significant-drag? db e))))
-
-(defn snap-to-angle?
-  [db e]
-  (and (:pointer-offset db)
-       (or (:ctrl-key e)
-           (tool.handlers/multi-touch? db))))
-
-(defn adjusted-pointer-pos
-  [db e]
-  (let [{:keys [adjusted-pointer-offset]} db
-        {:keys [pointer-pos]} e]
-    (cond->> (adjusted-pos db pointer-pos)
-      (snap-to-angle? db e)
-      (snap-angle adjusted-pointer-offset))))
-
-(m/=> on-pointer-move [:-> App PointerEvent App])
-(defn on-pointer-move
-  [db e]
-  (let [{:keys [drag-pointer]} db
-        {:keys [pointer-pos]} e
-        multi-touch? (tool.handlers/multi-touch? db)]
-    (if (and multi-touch? (not drag-pointer))
-      (on-pinch db e)
-      (cond-> (if (drag? db e)
-                (on-drag db e)
-                (tool.hierarchy/on-pointer-move db e))
-
-        (or (drag-pointer? db e) (not drag-pointer))
-        (assoc :pointer-pos pointer-pos
-               :adjusted-pointer-pos (adjusted-pointer-pos db e))))))
-
-(m/=> on-pointer-down [:-> App PointerEvent App])
-(defn on-pointer-down
-  [db e]
-  (let [{:keys [nearest-neighbor active-pointers]} db
-        {:keys [button pointer-pos pointer-id]} e]
-    (cond-> db
-      (not= button :right)
-      (assoc-in [:active-pointers pointer-id] e)
-
-      (= button :middle)
-      (-> (tool.handlers/set-cached ::tool.impl.base.pan/pan))
-
-      (or (= button :middle)
-          (and (= button :left) (empty? active-pointers)))
-      (assoc :pointer-offset pointer-pos
-             :adjusted-pointer-offset (adjusted-pos db pointer-pos)
-             :nearest-neighbor-offset (:point nearest-neighbor))
-
-      (or (= button :middle)
-          (empty? active-pointers))
-      (-> (tool.hierarchy/on-pointer-down e)
-          (app.handlers/add-fx [::effects/focus-canvas nil])))))
-
-(m/=> db-click? [:-> App PointerEvent boolean?])
-(defn db-click?
-  [db e]
-  (let [{:keys [double-click-delta event-timestamp]} db
-        {:keys [timestamp]} e
-        timestamp-delta (- timestamp event-timestamp)]
-    (< 0 timestamp-delta double-click-delta)))
-
-(m/=> on-pointer-up [:-> App PointerEvent App])
-(defn on-pointer-up
-  [db e]
-  (let [{:keys [cached-tool active-pointers pinch-distance drag-pointer]} db
-        {:keys [button timestamp pointer-id]} e
-        db (snap.handlers/update-nearest-neighbors db)]
-    (if pinch-distance
-      (cond-> db
-        :always
-        (update :active-pointers dissoc pointer-id)
-
-        (<= (count active-pointers) 2)
-        (-> (tool.handlers/clear-pointer-data)
-            (snap.handlers/update-viewport-tree)))
-      (cond-> (if drag-pointer
-                (cond-> db
-                  (drag-pointer? db e)
-                  (on-drag-end e))
-                (if (db-click? db e)
-                  (-> (dissoc db :event-timestamp)
-                      (tool.hierarchy/on-double-click e))
-                  (-> (assoc db :event-timestamp timestamp)
-                      (tool.hierarchy/on-pointer-up e))))
-
-        (and cached-tool (= button :middle))
-        (tool.handlers/reset-cached)
-
-        (not (tool.handlers/multi-touch? db))
-        (tool.handlers/clear-pointer-data)
-
-        :always
-        (update :active-pointers dissoc pointer-id)))))
+      (assoc :active-pointers {})
+      (dissoc :drag-pointer :pointer-offset :adjusted-pointer-offset
+              :nearest-neighbor :nearest-neighbor-offset
+              :pinch-distance :pinch-midpoint)))
 
 (m/=> pointer [:-> App PointerEvent App])
 (defn pointer
   [db e]
-  (let [{:keys [active-pointers]} db
-        {:keys [pointer-id button]} e
-        db (snap.handlers/update-nearest-neighbors db)]
-    (case (:type e)
-      "pointermove"
-      (on-pointer-move db e)
-
-      "pointerdown"
-      (on-pointer-down db e)
-
-      "pointerup"
-      (cond-> db
-        (and (contains? active-pointers pointer-id)
-             (not= button :right))
-        (on-pointer-up e))
-
-      "contextmenu"
-      (tool.hierarchy/on-context-menu db e)
-
-      db)))
-
-(m/=> on-key-down [:-> App KeyboardEvent App])
-(defn on-key-down
-  [db e]
-  (cond-> db
-    (and (= (:code e) "Space")
-         (not= (:tool db) ::tool.impl.base.pan/pan))
-    (tool.handlers/set-cached ::tool.impl.base.pan/pan)
-
-    (and (= (:code e) "KeyX")
-         (not (-> db :snap :transient-active)))
-    (-> (assoc-in [:snap :transient-active] true)
-        (cond->
-         (not (-> db :snap :active))
-          (-> (dissoc :nearest-neighbor)
-              (snap.handlers/rebuild-tree))))
-
-    (and (= (:key e) "Alt")
-         (= (:state db) :idle))
-    (assoc-in [:menubar :indicator] true)
-
-    :always
-    (tool.hierarchy/on-key-down e)))
-
-(m/=> on-key-up [:-> App KeyboardEvent App])
-(defn on-key-up
-  [db e]
-  (cond-> db
-    (and (= (:code e) "Space")
-         (:cached-tool db))
-    (tool.handlers/reset-cached)
-
-    (= (:code e) "KeyX")
-    (-> (assoc-in [:snap :transient-active] false)
-        (cond->
-         (not (-> db :snap :active))
-          (dissoc :nearest-neighbor)))
-
-    (= (:key e) "Alt")
-    (assoc-in [:menubar :indicator] false)
-
-    :always
-    (tool.hierarchy/on-key-up e)))
+  (-> db
+      (snap.handlers/update-nearest-neighbors)
+      (input.hierarchy/pointer e)))
 
 (m/=> keyboard [:-> App KeyboardEvent App])
 (defn keyboard
   [db e]
-  (case (:type e)
-    "keydown"
-    (on-key-down db e)
-
-    "keyup"
-    (on-key-up db e)
-
-    db))
+  (input.hierarchy/keyboard db e))
 
 (m/=> wheel [:-> App WheelEvent App])
 (defn wheel
   [db e]
-  (let [{:keys [delta-x delta-y ctrl-key shift-key]} e]
-    (-> (if (or ctrl-key shift-key)
-          (let [factor (-> (:zoom-sensitivity db)
-                           dec (/ 100) inc
-                           (Math/pow delta-y))]
-            (frame.handlers/zoom-at-pointer db factor))
-          (frame.handlers/pan-by db [delta-x delta-y]))
-        (snap.handlers/update-viewport-tree)
-        (app.handlers/add-fx [::app.effects/persist]))))
+  (input.hierarchy/wheel db e))
 
 (m/=> drag [:-> App DragEvent App])
 (defn drag
   [db e]
-  (case (:type e)
-    "drop"
-    (let [{:keys [data-transfer pointer-pos]} e
-          position (adjusted-pos db pointer-pos)]
-      (app.handlers/add-fx db [::input.effects/drop [position data-transfer]]))
-
-    db))
+  (input.hierarchy/wheel db e))

--- a/src/renderer/input/hierarchy.cljs
+++ b/src/renderer/input/hierarchy.cljs
@@ -1,0 +1,10 @@
+(ns renderer.input.hierarchy)
+
+(defmulti keyboard (fn [_db e] (:type e)))
+(defmulti pointer (fn [_db e] (:type e)))
+(defmulti wheel (fn [_db e] (:type e)))
+(defmulti drag (fn [_db e] (:type e)))
+
+(defmethod keyboard :default [db _e] db)
+(defmethod pointer :default [db _e] db)
+(defmethod drag :default [db _e] db)

--- a/src/renderer/input/impl/drag.cljs
+++ b/src/renderer/input/impl/drag.cljs
@@ -2,9 +2,13 @@
   (:require
    [malli.core :as m]
    [re-frame.core :as rf]
+   [renderer.app.handlers :as app.handlers]
    [renderer.db :refer [JS_Object]]
    [renderer.input.db :refer [DragEvent]]
-   [renderer.input.events :as-alias input.events]))
+   [renderer.input.effects :as-alias input.effects]
+   [renderer.input.events :as-alias input.events]
+   [renderer.input.handlers :as input.handlers]
+   [renderer.input.hierarchy :as input.hierarchy]))
 
 (m/=> ->clj [:-> JS_Object DragEvent])
 (defn ->clj
@@ -21,3 +25,9 @@
   (.preventDefault e)
 
   (rf/dispatch-sync [::input.events/drag (->clj e)]))
+
+(defmethod input.hierarchy/drag "drop"
+  [db e]
+  (let [{:keys [data-transfer pointer-pos]} e
+        position (input.handlers/adjusted-pos db pointer-pos)]
+    (app.handlers/add-fx db [::input.effects/drop [position data-transfer]])))

--- a/src/renderer/input/impl/keyboard.cljs
+++ b/src/renderer/input/impl/keyboard.cljs
@@ -4,7 +4,12 @@
    [re-frame.core :as rf]
    [renderer.db :refer [JS_Object]]
    [renderer.input.db :refer [KeyboardEvent]]
-   [renderer.input.events :as-alias input.events]))
+   [renderer.input.events :as-alias input.events]
+   [renderer.input.hierarchy :as input.hierarchy]
+   [renderer.snap.handlers :as snap.handlers]
+   [renderer.tool.handlers :as tool.handlers]
+   [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.pan :as-alias tool.impl.base.pan]))
 
 (m/=> ->clj [:-> JS_Object KeyboardEvent])
 (defn ->clj
@@ -24,3 +29,44 @@
 (defn handler!
   [^js/KeyboardEvent e]
   (rf/dispatch-sync [::input.events/keyboard (->clj e)]))
+
+(defmethod input.hierarchy/keyboard "keydown"
+  [db e]
+  (cond-> db
+    (and (= (:code e) "Space")
+         (not= (:tool db) ::tool.impl.base.pan/pan))
+    (tool.handlers/set-cached ::tool.impl.base.pan/pan)
+
+    (and (= (:code e) "KeyX")
+         (not (-> db :snap :transient-active)))
+    (-> (assoc-in [:snap :transient-active] true)
+        (cond->
+         (not (-> db :snap :active))
+          (-> (dissoc :nearest-neighbor)
+              (snap.handlers/rebuild-tree))))
+
+    (and (= (:key e) "Alt")
+         (= (:state db) :idle))
+    (assoc-in [:menubar :indicator] true)
+
+    :always
+    (tool.hierarchy/on-key-down e)))
+
+(defmethod input.hierarchy/keyboard "keyup"
+  [db e]
+  (cond-> db
+    (and (= (:code e) "Space")
+         (:cached-tool db))
+    (tool.handlers/reset-cached)
+
+    (= (:code e) "KeyX")
+    (-> (assoc-in [:snap :transient-active] false)
+        (cond->
+         (not (-> db :snap :active))
+          (dissoc :nearest-neighbor)))
+
+    (= (:key e) "Alt")
+    (assoc-in [:menubar :indicator] false)
+
+    :always
+    (tool.hierarchy/on-key-up e)))

--- a/src/renderer/input/impl/pointer.cljs
+++ b/src/renderer/input/impl/pointer.cljs
@@ -1,12 +1,24 @@
 (ns renderer.input.impl.pointer
   (:require
+   [clojure.core.matrix :as matrix]
    [malli.core :as m]
    [re-frame.core :as rf]
+   [renderer.app.db :refer [App]]
+   [renderer.app.handlers :as app.handlers]
    [renderer.db :refer [JS_Object]]
+   [renderer.effects :as-alias effects]
    [renderer.element.db :refer [Element]]
+   [renderer.frame.handlers :as frame.handlers]
    [renderer.input.db :refer [PointerEvent PointerButton]]
+   [renderer.input.effects :as-alias input.effects]
    [renderer.input.events :as-alias input.events]
-   [renderer.tool.db :refer [Handle]]))
+   [renderer.input.handlers :as input.handlers]
+   [renderer.input.hierarchy :as input.hierarchy]
+   [renderer.snap.handlers :as snap.handlers]
+   [renderer.tool.db :refer [Handle]]
+   [renderer.tool.handlers :as tool.handlers]
+   [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.impl.base.pan :as-alias tool.impl.base.pan]))
 
 (m/=> button->key [:-> [:enum -1 0 1 2 3 4] [:maybe PointerButton]])
 (defn button->key
@@ -49,3 +61,188 @@
   ;; the end result appears to be more responsive because it's synced with the
   ;; pointer movement.
   (rf/dispatch-sync [::input.events/pointer (->clj el e)]))
+
+(m/=> drag-pointer? [:-> App PointerEvent boolean?])
+(defn drag-pointer?
+  [db e]
+  (= (:drag-pointer db)
+     (:pointer-id e)))
+
+(m/=> on-drag-start [:-> App PointerEvent App])
+(defn on-drag-start
+  [db {:keys [pointer-id]
+       :as e}]
+  (-> db
+      (assoc :drag-pointer pointer-id)
+      (tool.hierarchy/on-drag-start e)
+      (app.handlers/add-fx [::input.effects/set-pointer-capture pointer-id])))
+
+(m/=> on-pinch [:-> App PointerEvent App])
+(defn on-pinch
+  [db e]
+  (let [{:keys [active-pointers pinch-distance pinch-midpoint]} db
+        {:keys [pointer-id]} e
+        active-pointers (assoc active-pointers pointer-id e)
+        [pos1 pos2] (->> (vals active-pointers)
+                         (take 2)
+                         (map :pointer-pos))
+        distance (matrix/distance pos1 pos2)
+        midpoint (-> (matrix/add pos1 pos2)
+                     (matrix/div 2))
+        adjusted-midpoint (input.handlers/adjusted-pos db midpoint)]
+    (cond-> db
+      :always
+      (assoc :active-pointers active-pointers
+             :pinch-distance distance
+             :pinch-midpoint midpoint)
+
+      pinch-distance
+      (-> (frame.handlers/pan-by (matrix/sub pinch-midpoint midpoint))
+          (frame.handlers/zoom-at-position (/ distance pinch-distance)
+                                           adjusted-midpoint)))))
+
+(m/=> on-drag [:-> App PointerEvent App])
+(defn on-drag
+  [db e]
+  (let [{:keys [pointer-offset tool dom-rect drag-pointer]} db
+        {:keys [pointer-pos]} e]
+    (cond-> db
+      (and (not= tool ::tool.impl.base.pan/pan)
+           (drag-pointer? db e))
+      (tool.handlers/pan-out-of-canvas dom-rect pointer-pos pointer-offset)
+
+      (not drag-pointer)
+      (on-drag-start e)
+
+      :always
+      (tool.hierarchy/on-drag e))))
+
+(m/=> significant-drag? [:-> App PointerEvent boolean?])
+(defn significant-drag?
+  [db e]
+  (let [{:keys [pointer-offset drag-threshold]} db
+        {:keys [pointer-pos]} e]
+    (> (matrix/distance pointer-offset pointer-pos)
+       drag-threshold)))
+
+(defn drag?
+  [db e]
+  (let [{:keys [pointer-offset active-pointers]} db
+        {:keys [pointer-id]} e]
+    (and pointer-offset
+         (contains? active-pointers pointer-id)
+         (significant-drag? db e))))
+
+(defn snap-to-angle?
+  [db e]
+  (and (:pointer-offset db)
+       (or (:ctrl-key e)
+           (input.handlers/multi-touch? db))))
+
+(defn adjusted-pointer-pos
+  [db e]
+  (let [{:keys [adjusted-pointer-offset]} db
+        {:keys [pointer-pos]} e]
+    (cond->> (input.handlers/adjusted-pos db pointer-pos)
+      (snap-to-angle? db e)
+      (input.handlers/snap-angle adjusted-pointer-offset))))
+
+(defmethod input.hierarchy/pointer "pointermove"
+  [db e]
+  (let [{:keys [drag-pointer]} db
+        {:keys [pointer-pos]} e
+        multi-touch? (input.handlers/multi-touch? db)]
+    (if (and multi-touch? (not drag-pointer))
+      (on-pinch db e)
+      (cond-> (if (drag? db e)
+                (on-drag db e)
+                (tool.hierarchy/on-pointer-move db e))
+
+        (or (drag-pointer? db e) (not drag-pointer))
+        (assoc :pointer-pos pointer-pos
+               :adjusted-pointer-pos (adjusted-pointer-pos db e))))))
+
+(defmethod input.hierarchy/pointer "pointerdown"
+  [db e]
+  (let [{:keys [nearest-neighbor active-pointers]} db
+        {:keys [button pointer-pos pointer-id]} e]
+    (cond-> db
+      (not= button :right)
+      (assoc-in [:active-pointers pointer-id] e)
+
+      (= button :middle)
+      (-> (tool.handlers/set-cached ::tool.impl.base.pan/pan))
+
+      (or (= button :middle)
+          (and (= button :left) (empty? active-pointers)))
+      (assoc :pointer-offset pointer-pos
+             :adjusted-pointer-offset (input.handlers/adjusted-pos db
+                                                                   pointer-pos)
+             :nearest-neighbor-offset (:point nearest-neighbor))
+
+      (or (= button :middle)
+          (empty? active-pointers))
+      (-> (tool.hierarchy/on-pointer-down e)
+          (app.handlers/add-fx [::effects/focus-canvas nil])))))
+
+(m/=> db-click? [:-> App PointerEvent boolean?])
+(defn db-click?
+  [db e]
+  (let [{:keys [double-click-delta event-timestamp]} db
+        {:keys [timestamp]} e
+        timestamp-delta (- timestamp event-timestamp)]
+    (< 0 timestamp-delta double-click-delta)))
+
+(m/=> on-drag-end [:-> App PointerEvent App])
+(defn on-drag-end
+  [db {:keys [pointer-id]
+       :as e}]
+  (-> db
+      (tool.hierarchy/on-drag-end e)
+      (input.handlers/clear-pointer-data)
+      (app.handlers/add-fx [::input.effects/release-pointer-capture
+                            pointer-id])))
+
+(defn on-pointer-up
+  [db e]
+  (let [{:keys [cached-tool active-pointers pinch-distance drag-pointer]} db
+        {:keys [button timestamp pointer-id]} e]
+    (if pinch-distance
+      (cond-> db
+        :always
+        (update :active-pointers dissoc pointer-id)
+
+        (<= (count active-pointers) 2)
+        (-> (input.handlers/clear-pointer-data)
+            (snap.handlers/update-viewport-tree)))
+      (cond-> (if drag-pointer
+                (cond-> db
+                  (drag-pointer? db e)
+                  (on-drag-end e))
+                (if (db-click? db e)
+                  (-> (dissoc db :event-timestamp)
+                      (tool.hierarchy/on-double-click e))
+                  (-> (assoc db :event-timestamp timestamp)
+                      (tool.hierarchy/on-pointer-up e))))
+
+        (and cached-tool (= button :middle))
+        (tool.handlers/reset-cached)
+
+        (not (input.handlers/multi-touch? db))
+        (input.handlers/clear-pointer-data)
+
+        :always
+        (update :active-pointers dissoc pointer-id)))))
+
+(defmethod input.hierarchy/pointer "pointerup"
+  [db e]
+  (let [{:keys [active-pointers]} db
+        {:keys [button pointer-id]} e]
+    (cond-> db
+      (and (contains? active-pointers pointer-id)
+           (not= button :right))
+      (on-pointer-up e))))
+
+(defmethod input.hierarchy/pointer "contextmenu"
+  [db e]
+  (tool.hierarchy/on-context-menu db e))

--- a/src/renderer/input/impl/pointer.cljs
+++ b/src/renderer/input/impl/pointer.cljs
@@ -5,7 +5,7 @@
    [re-frame.core :as rf]
    [renderer.app.db :refer [App]]
    [renderer.app.handlers :as app.handlers]
-   [renderer.db :refer [JS_Object]]
+   [renderer.db :refer [JS_Object Vec2]]
    [renderer.effects :as-alias effects]
    [renderer.element.db :refer [Element]]
    [renderer.frame.handlers :as frame.handlers]
@@ -125,6 +125,7 @@
     (> (matrix/distance pointer-offset pointer-pos)
        drag-threshold)))
 
+(m/=> drag? [:-> App PointerEvent boolean?])
 (defn drag?
   [db e]
   (let [{:keys [pointer-offset active-pointers]} db
@@ -133,12 +134,14 @@
          (contains? active-pointers pointer-id)
          (significant-drag? db e))))
 
+(m/=> snap-to-angle? [:-> App PointerEvent boolean?])
 (defn snap-to-angle?
   [db e]
   (and (:pointer-offset db)
        (or (:ctrl-key e)
            (input.handlers/multi-touch? db))))
 
+(m/=> adjusted-pointer-pos [:-> App PointerEvent Vec2])
 (defn adjusted-pointer-pos
   [db e]
   (let [{:keys [adjusted-pointer-offset]} db
@@ -203,6 +206,7 @@
       (app.handlers/add-fx [::input.effects/release-pointer-capture
                             pointer-id])))
 
+(m/=> on-pointer-up [:-> App PointerEvent App])
 (defn on-pointer-up
   [db e]
   (let [{:keys [cached-tool active-pointers pinch-distance drag-pointer]} db

--- a/src/renderer/input/impl/wheel.cljs
+++ b/src/renderer/input/impl/wheel.cljs
@@ -2,8 +2,13 @@
   (:require
    [malli.core :as m]
    [re-frame.core :as rf]
+   [renderer.app.effects :as-alias app.effects]
+   [renderer.app.handlers :as app.handlers]
+   [renderer.frame.handlers :as frame.handlers]
    [renderer.input.db :refer [WheelEvent]]
-   [renderer.input.events :as-alias input.events]))
+   [renderer.input.events :as-alias input.events]
+   [renderer.input.hierarchy :as input.hierarchy]
+   [renderer.snap.handlers :as snap.handlers]))
 
 (m/=> ->clj [:-> any? WheelEvent])
 (defn ->clj
@@ -27,3 +32,15 @@
   (.preventDefault e)
 
   (rf/dispatch-sync [::input.events/wheel (->clj e)]))
+
+(defmethod input.hierarchy/wheel :default
+  [db e]
+  (let [{:keys [delta-x delta-y ctrl-key shift-key]} e]
+    (-> (if (or ctrl-key shift-key)
+          (let [factor (-> (:zoom-sensitivity db)
+                           dec (/ 100) inc
+                           (Math/pow delta-y))]
+            (frame.handlers/zoom-at-pointer db factor))
+          (frame.handlers/pan-by db [delta-x delta-y]))
+        (snap.handlers/update-viewport-tree)
+        (app.handlers/add-fx [::app.effects/persist]))))

--- a/src/renderer/input/subs.cljs
+++ b/src/renderer/input/subs.cljs
@@ -1,0 +1,45 @@
+(ns renderer.input.subs
+  (:require
+   [re-frame.core :as rf]
+   [renderer.tool.handlers :as tool.handlers]))
+
+(rf/reg-sub
+ ::active-pointers
+ :-> :active-pointers)
+
+(rf/reg-sub
+ ::pinch-distance
+ :-> :pinch-distance)
+
+(rf/reg-sub
+ ::pointer-pos
+ :-> :pointer-pos)
+
+(rf/reg-sub
+ ::adjusted-pointer-pos
+ :-> :adjusted-pointer-pos)
+
+(rf/reg-sub
+ ::pointer-offset
+ :-> :pointer-offset)
+
+(rf/reg-sub
+ ::drag-pointer
+ :-> :drag-pointer)
+
+(rf/reg-sub
+ ::adjusted-pointer-offset
+ :-> :adjusted-pointer-offset)
+
+(rf/reg-sub
+ ::drag?
+ :<- [::drag-pointer]
+ :-> boolean)
+
+(rf/reg-sub
+ ::snapped-position
+ :-> tool.handlers/snapped-position)
+
+(rf/reg-sub
+ ::snapped-offset
+ :-> tool.handlers/snapped-offset)

--- a/src/renderer/ruler/views.cljs
+++ b/src/renderer/ruler/views.cljs
@@ -2,10 +2,10 @@
   (:require
    [clojure.string :as string]
    [re-frame.core :as rf]
-   [renderer.app.subs :as-alias app.subs]
    [renderer.document.subs :as-alias document.subs]
    [renderer.element.subs :as-alias element.subs]
    [renderer.frame.subs :as-alias frame.subs]
+   [renderer.input.subs :as-alias input.subs]
    [renderer.ruler.subs :as-alias ruler.subs]
    [renderer.tool.events :as tool.events]
    [renderer.tool.impl.misc.guide :as-alias tool.impl.misc.guide]
@@ -33,7 +33,7 @@
 
 (defn pointer
   [orientation]
-  (let [[x y] @(rf/subscribe [::app.subs/pointer-pos])
+  (let [[x y] @(rf/subscribe [::input.subs/pointer-pos])
         pointer-size (/ ruler-size 5)
         color "var(--color-accent)"
         vertical (= orientation :vertical)]

--- a/src/renderer/tool/handlers.cljs
+++ b/src/renderer/tool/handlers.cljs
@@ -7,6 +7,7 @@
    [renderer.frame.db :refer [DomRect]]
    [renderer.frame.handlers :as frame.handlers]
    [renderer.history.handlers :as history.handlers]
+   [renderer.input.handlers :as input.handlers]
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.db :refer [Tool State Cursor]]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -91,19 +92,6 @@
 
       :else 0)))
 
-(m/=> clear-pointer-data [:-> App App])
-(defn clear-pointer-data
-  [db]
-  (-> db
-      (assoc :active-pointers {})
-      (dissoc :drag-pointer :pointer-offset :adjusted-pointer-offset
-              :nearest-neighbor :nearest-neighbor-offset
-              :pinch-distance :pinch-midpoint)))
-
-(defn multi-touch?
-  [db]
-  (> (count (:active-pointers db)) 1))
-
 (m/=> pan-out-of-canvas [:-> App DomRect Vec2 Vec2 App])
 (defn pan-out-of-canvas
   [db dom-rect pointer-pos pointer-offset]
@@ -147,5 +135,5 @@
     (reset-cached)
 
     :always
-    (-> (clear-pointer-data)
+    (-> (input.handlers/clear-pointer-data)
         (set-state :idle))))

--- a/src/renderer/tool/impl/base/edit.cljs
+++ b/src/renderer/tool/impl/base/edit.cljs
@@ -10,6 +10,7 @@
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
+   [renderer.input.handlers :as input.handlers]
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
@@ -77,7 +78,7 @@
 (defmethod tool.hierarchy/on-drag [::edit :edit]
   [db e]
   (let [{:keys [element-id id]} (:clicked-element db)
-        lock? (or (:ctrl-key e) (tool.handlers/multi-touch? db))
+        lock? (or (:ctrl-key e) (input.handlers/multi-touch? db))
         offset (matrix/add (tool.handlers/pointer-delta db)
                            (snap.handlers/nearest-delta db))]
     (cond-> db

--- a/src/renderer/tool/impl/base/transform/scale.cljs
+++ b/src/renderer/tool/impl/base/transform/scale.cljs
@@ -7,6 +7,7 @@
    [renderer.element.handlers :as element.handlers]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
+   [renderer.input.handlers :as input.handlers]
    [renderer.snap.handlers :as snap.handlers]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -131,7 +132,7 @@
 (defn ratio-locked?
   [db e]
   (or (:ctrl-key e)
-      (tool.handlers/multi-touch? db)
+      (input.handlers/multi-touch? db)
       (element.handlers/ratio-locked? db)))
 
 (defmethod tool.hierarchy/on-drag [::transform/transform :scale]

--- a/src/renderer/tool/impl/base/transform/select.cljs
+++ b/src/renderer/tool/impl/base/transform/select.cljs
@@ -10,6 +10,7 @@
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
+   [renderer.input.handlers :as input.handlers]
    [renderer.tool.db :refer [Handle]]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -60,7 +61,7 @@
 (defn reduce-by-area
   [db e f]
   (let [{:keys [alt-key]} e
-        intersecting? (or alt-key (tool.handlers/multi-touch? db))]
+        intersecting? (or alt-key (input.handlers/multi-touch? db))]
     (transduce
      (comp
       (element.handlers/visible)

--- a/src/renderer/tool/impl/element/path.cljs
+++ b/src/renderer/tool/impl/element/path.cljs
@@ -8,13 +8,13 @@
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
    [renderer.app.db :refer [App]]
-   [renderer.app.subs :as-alias app.subs]
    [renderer.db :refer [Vec2]]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
+   [renderer.input.subs :as-alias input.subs]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -148,9 +148,9 @@
 
 (defmethod tool.hierarchy/render ::path
   []
-  (let [starting-point @(rf/subscribe [::tool.subs/snapped-position])
-        ending-point @(rf/subscribe [::tool.subs/snapped-offset])
-        drag? @(rf/subscribe [::app.subs/drag?])]
+  (let [starting-point @(rf/subscribe [::input.subs/snapped-position])
+        ending-point @(rf/subscribe [::input.subs/snapped-offset])
+        drag? @(rf/subscribe [::input.subs/drag?])]
     (when drag?
       [utils.svg/arm starting-point ending-point])))
 

--- a/src/renderer/tool/impl/misc/guide.cljs
+++ b/src/renderer/tool/impl/misc/guide.cljs
@@ -8,7 +8,7 @@
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
-   [renderer.input.handlers :as input.handlers]
+   [renderer.input.impl.pointer :as input.impl.pointer]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -55,7 +55,7 @@
   (-> db
       (history.handlers/reset-state)
       (assoc-in [:active-pointers pointer-id] e)
-      (input.handlers/on-drag-start e)))
+      (input.impl.pointer/on-drag-start e)))
 
 (defmethod tool.hierarchy/on-pointer-move [::guide :create]
   [db _e]

--- a/src/renderer/tool/subs.cljs
+++ b/src/renderer/tool/subs.cljs
@@ -36,23 +36,6 @@
  :-> :anchor-offset)
 
 (rf/reg-sub
- ::drag-pointer
- :-> :drag-pointer)
-
-(rf/reg-sub
- ::snapped-position
- :-> tool.handlers/snapped-position)
-
-(rf/reg-sub
- ::snapped-offset
- :-> tool.handlers/snapped-offset)
-
-(rf/reg-sub
- ::drag?
- :<- [::drag-pointer]
- boolean)
-
-(rf/reg-sub
  ::cursor
  :-> :cursor)
 

--- a/src/renderer/toolbar/status.cljs
+++ b/src/renderer/toolbar/status.cljs
@@ -6,12 +6,12 @@
    ["@repath-studio/react-color" :refer [ChromePicker PhotoshopPicker]]
    [re-frame.core :as rf]
    [renderer.action.views :as action.views]
-   [renderer.app.subs :as-alias app.subs]
    [renderer.document.events :as-alias document.events]
    [renderer.document.subs :as-alias document.subs]
    [renderer.element.events :as-alias element.events]
    [renderer.frame.events :as-alias frame.events]
    [renderer.i18n.views :as i18n.views]
+   [renderer.input.subs :as-alias input.subs]
    [renderer.snap.views :as snap.views]
    [renderer.timeline.views :as timeline.views]
    [renderer.utils.key :as utils.key]
@@ -20,7 +20,7 @@
    [renderer.window.subs :as-alias window.subs]))
 
 (defn coordinates []
-  (let [[x y] @(rf/subscribe [::app.subs/adjusted-pointer-pos])]
+  (let [[x y] @(rf/subscribe [::input.subs/adjusted-pointer-pos])]
     [:div.flex-col.font-mono.leading-tight.hidden.mx-1
      {:class "xl:flex"
       :style {:min-width "90px"}


### PR DESCRIPTION
The motivation behind this PR was to reduce the size of `renderer.input.handlers` by introducing input related multi-methods. The input handling now lives under the corresponding implementations (eg `renderer.input.impl.pointer`). We also moved some subs and other input related functions under this module.