### PR TITLE
Path enhancements

### DIFF
--- a/src/renderer/element/hierarchy.cljs
+++ b/src/renderer/element/hierarchy.cljs
@@ -31,8 +31,12 @@
   (fn [el _ratio _pivot-point] (:tag el))
   :hierarchy hierarchy/hierarchy)
 
-(defmulti edit
+(defmulti edit-drag
   (fn [el _offset _handle _lock?] (:tag el))
+  :hierarchy hierarchy/hierarchy)
+
+(defmulti edit-click
+  (fn [el _handle] (:tag el))
   :hierarchy hierarchy/hierarchy)
 
 (defmulti properties identity :hierarchy hierarchy/hierarchy)
@@ -46,5 +50,6 @@
 (defmethod snapping-points :default [] [])
 (defmethod translate :default [el _offset] el)
 (defmethod scale :default [el _ratio _pivot-point] el)
-(defmethod edit :default [el _offset _handle _lock?] el)
+(defmethod edit-drag :default [el _offset _handle _lock?] el)
+(defmethod edit-click :default [el _handle] el)
 (defmethod properties :default [])

--- a/src/renderer/element/impl/box.cljs
+++ b/src/renderer/element/impl/box.cljs
@@ -27,7 +27,7 @@
         (attribute.hierarchy/update-attr :height * y)
         (element.hierarchy/translate offset))))
 
-(defmethod element.hierarchy/edit ::element.hierarchy/box
+(defmethod element.hierarchy/edit-drag ::element.hierarchy/box
   [el offset handle lock?]
   (let [[x y] (cond-> offset
                 lock?

--- a/src/renderer/element/impl/custom/blob.cljs
+++ b/src/renderer/element/impl/custom/blob.cljs
@@ -156,7 +156,7 @@
         (.translate x y)
         (.toString))))
 
-(defmethod element.hierarchy/edit :blob
+(defmethod element.hierarchy/edit-drag :blob
   [el [x y] handle _lock?]
   (case handle
     :size

--- a/src/renderer/element/impl/custom/brush.cljs
+++ b/src/renderer/element/impl/custom/brush.cljs
@@ -195,7 +195,7 @@
                                             :element-id (:id el)}])))
        (into [:g])))
 
-(defmethod element.hierarchy/edit :brush
+(defmethod element.hierarchy/edit-drag :brush
   [el offset handle lock?]
   (let [index (js/parseInt (name handle))
         [x y] (cond-> offset

--- a/src/renderer/element/impl/custom/guide.cljs
+++ b/src/renderer/element/impl/custom/guide.cljs
@@ -80,7 +80,7 @@
 
 (defmethod element.hierarchy/render-to-string :guide [_el] nil)
 
-(defmethod element.hierarchy/edit :guide
+(defmethod element.hierarchy/edit-drag :guide
   [el offset handle lock?]
   (let [[x y] (cond-> offset
                 lock?

--- a/src/renderer/element/impl/shape/circle.cljs
+++ b/src/renderer/element/impl/shape/circle.cljs
@@ -69,7 +69,7 @@
                       "A" r r 0 0 1 (+ cx r) cy
                       "z"])))
 
-(defmethod element.hierarchy/edit :circle
+(defmethod element.hierarchy/edit-drag :circle
   [el [x _y] handle _lock?]
   (case handle
     :r (attribute.hierarchy/update-attr el :r #(abs (+ % x)))

--- a/src/renderer/element/impl/shape/ellipse.cljs
+++ b/src/renderer/element/impl/shape/ellipse.cljs
@@ -75,7 +75,7 @@
         [rx ry] (map utils.length/unit->px [rx ry])]
     (* Math/PI rx ry)))
 
-(defmethod element.hierarchy/edit :ellipse
+(defmethod element.hierarchy/edit-drag :ellipse
   [el [x y] handle _lock?]
   (let [{{:keys [rx ry]} :attrs} el]
     (case handle

--- a/src/renderer/element/impl/shape/line.cljs
+++ b/src/renderer/element/impl/shape/line.cljs
@@ -101,7 +101,7 @@
             :action :edit
             :element-id (:id el)}])]))
 
-(defmethod element.hierarchy/edit :line
+(defmethod element.hierarchy/edit-drag :line
   [el offset handle lock?]
   (let [[x y] (cond-> offset
                 lock?

--- a/src/renderer/element/impl/shape/path.cljs
+++ b/src/renderer/element/impl/shape/path.cljs
@@ -64,7 +64,7 @@
            (mapv utils.length/unit->px)))
 
 (defn render-arms
-  [endpoints offset index segment]
+  [{:keys [endpoints segments offset]} index segment]
   (let [prev-ep (some-> (get endpoints (dec index)) (matrix/add offset))
         cp0 (some-> segment
                     (->px-point :start-control-point)
@@ -80,7 +80,12 @@
          [utils.svg/arm cp1 ep]])
 
       "S"
-      [utils.svg/arm cp0 ep]
+      [:<>
+       (when-let [implied-cp1 (some-> (get segments (dec index))
+                                      utils.path/outgoing-cp
+                                      (matrix/add offset))]
+         [utils.svg/arm prev-ep implied-cp1])
+       [utils.svg/arm cp0 ep]]
 
       `"Q"
       [:<>
@@ -89,9 +94,11 @@
 
       nil)))
 
-(m/=> handles [:-> [:vector Vec2] int? PathSegment [:maybe [:vector map?]]])
+(m/=> handles [:->
+               [:vector Vec2] PathSegments int? PathSegment
+               [:maybe [:vector map?]]])
 (defn handles
-  [endpoints index segment]
+  [endpoints segments index segment]
   (let [command (utils.path/segment->command segment)
         prev-ep (get endpoints (dec index))]
     (case command
@@ -110,7 +117,22 @@
        {:point-type :end-point
         :pos (->px-point segment :end-point)}]
 
-      ("S" "Q")
+      "S"
+      (let [cp0 (->px-point segment :start-control-point)
+            implied-cp1 (some-> (get segments (dec index))
+                                utils.path/outgoing-cp
+                                (->> (mapv utils.length/unit->px)))]
+        (cond-> [{:point-type :start-control-point
+                  :pos cp0
+                  :rounded true}
+                 {:point-type :end-point
+                  :pos (->px-point segment :end-point)}]
+          implied-cp1 (conj {:point-type :implied-control-point
+                             :pos implied-cp1
+                             :rounded true
+                             :implied true})))
+
+      "Q"
       [{:point-type :start-control-point
         :pos (->px-point segment :start-control-point)
         :rounded true}
@@ -132,17 +154,21 @@
       nil)))
 
 (defn render-handles
-  [{:keys [element-id endpoints offset]} index segment]
-  (->> (handles endpoints index segment)
-       (map (fn [{:keys [point-type pos rounded]}]
-              (let [[ax ay] (matrix/add offset pos)]
-                [tool.views/handle {:id (keyword index point-type)
-                                    :x ax
-                                    :y ay
-                                    :type :handle
-                                    :action :edit
-                                    :rounded (boolean rounded)
-                                    :element-id element-id}])))
+  [{:keys [element-id endpoints segments offset]} index segment]
+  (->> (handles endpoints segments index segment)
+       (map (fn [{:keys [point-type pos rounded implied]}]
+              (let [[ax ay] (matrix/add offset pos)
+                    h [tool.views/handle {:id (keyword index point-type)
+                                          :x ax
+                                          :y ay
+                                          :type :handle
+                                          :action :edit
+                                          :rounded (boolean rounded)
+                                          :element-id element-id}]]
+                (if implied
+                  [:g {:pointer-events "none"
+                       :opacity 0.5} h]
+                  h))))
        (into [:g])))
 
 (m/=> acc-endpoints [:-> PathSegments [:vector Vec2]])
@@ -153,19 +179,54 @@
                  (utils.path/abs-endpoint segment)
                  (conj acc))) [] segments))
 
+(defn c->s-segment
+  [segment]
+  (let [[_ _cp1x _cp1y cp2x cp2y x y] segment]
+    ["S" cp2x cp2y x y]))
+
+(defn s->c-segment
+  [segments index]
+  (let [[_ cp2x cp2y x y] (get segments index)
+        prev-segment (get segments (dec index))
+        endpoints (acc-endpoints segments)
+        prev-ep (get endpoints (dec index))
+        [cp1x cp1y] (or (utils.path/outgoing-cp prev-segment) prev-ep)]
+    ["C" cp1x cp1y cp2x cp2y x y]))
+
+(defn toggle-command
+  [segments index]
+  (let [segment (get segments index)
+        command (utils.path/segment->command segment)]
+    (case command
+      "C" (assoc segments index (c->s-segment segment))
+      "S" (assoc segments index (s->c-segment segments index))
+      segments)))
+
+(defmethod element.hierarchy/edit-click :path
+  [el handle]
+  (let [point-type (keyword (name handle))]
+    (if (= point-type :end-point)
+      (let [index (inc (js/parseInt (namespace handle)))]
+        (update-in el [:attrs :d]
+                   #(some-> %
+                            utils.path/string->segments
+                            (toggle-command index)
+                            utils.path/segments->string)))
+      el)))
+
 (defmethod element.hierarchy/render-edit :path
   [el]
-  (let [offset (utils.element/offset el)
-        segments (->> el :attrs :d utils.path/string->segments)
-        endpoints (acc-endpoints segments)]
+  (let [segments (->> el :attrs :d utils.path/string->segments)
+        props {:element-id (:id el)
+               :endpoints (acc-endpoints segments)
+               :segments segments
+               :offset (utils.element/offset el)}]
     [:g
      (->> segments
-          (map-indexed (partial render-arms endpoints offset))
+          (map-indexed (partial render-arms props))
           (into [:g]))
      (->> segments
-          (map-indexed (partial render-handles {:element-id (:id el)
-                                                :endpoints endpoints
-                                                :offset offset}))
+          (map-indexed (partial render-handles props))
           (into [:g]))]))
 
 (m/=> translate-seg-point [:->
@@ -203,15 +264,25 @@
 (defn translate-point
   [index point-type delta segments]
   (let [segments (translate-seg-point segments index point-type delta)]
-    (cond-> segments
-      (= point-type :end-point)
-      (-> (translate-seg-point index :end-control-point delta)
-          (translate-seg-point (inc index) :start-control-point delta)))))
+    (if (= point-type :end-point)
+      (let [cmd (utils.path/segment->command (get segments index))
+            next-cmd (utils.path/segment->command (get segments (inc index)))]
+        (cond-> segments
+          (= cmd "C")
+          (translate-seg-point index :end-control-point delta)
+
+          (= cmd "S")
+          (translate-seg-point index :start-control-point delta)
+
+          (not= next-cmd "S")
+          (translate-seg-point (inc index) :start-control-point delta)))
+      segments)))
 
 (defn snap-control-point-to-angle
   [segments index point-type offset]
   (let [endpoints (acc-endpoints segments)
-        anchor (if (= point-type :start-control-point)
+        cmd (utils.path/segment->command (get segments index))
+        anchor (if (and (= point-type :start-control-point) (not= cmd "S"))
                  (get endpoints (dec index))
                  (get endpoints index))
         cp-pos (->px-point (get segments index) point-type)
@@ -219,7 +290,7 @@
         snapped (input.handlers/snap-angle anchor new-cp-pos)]
     (matrix/sub snapped cp-pos)))
 
-(defmethod element.hierarchy/edit :path
+(defmethod element.hierarchy/edit-drag :path
   [el offset handle lock?]
   (let [point-type (keyword (name handle))
         index (js/parseInt (namespace handle))]

--- a/src/renderer/element/impl/shape/poly.cljs
+++ b/src/renderer/element/impl/shape/poly.cljs
@@ -92,7 +92,7 @@
          (map-indexed (partial render-handle el margin))
          (into [:g]))))
 
-(defmethod element.hierarchy/edit ::element.hierarchy/poly
+(defmethod element.hierarchy/edit-drag ::element.hierarchy/poly
   [el offset handle lock?]
   (let [index (js/parseInt (name handle))
         [x y] (cond-> offset lock? input.handlers/lock-direction)

--- a/src/renderer/element/impl/shape/rect.cljs
+++ b/src/renderer/element/impl/shape/rect.cljs
@@ -56,7 +56,7 @@
         (attribute.hierarchy/update-attr :rx min (/ width 2))
         (attribute.hierarchy/update-attr :ry min (/ height 2)))))
 
-(defmethod element.hierarchy/edit :rect
+(defmethod element.hierarchy/edit-drag :rect
   [el offset handle lock?]
   (let [[x y] (cond-> offset
                 (and (contains? #{:position :size} handle)

--- a/src/renderer/tool/impl/base/edit.cljs
+++ b/src/renderer/tool/impl/base/edit.cljs
@@ -48,16 +48,22 @@
 
 (defmethod tool.hierarchy/on-pointer-up [::edit :idle]
   [db e]
-  (let [{:keys [shift-key button element]} e]
-    (if-not (and (= button :right)
-                 (:selected element))
+  (let [{:keys [shift-key ctrl-key element]} e
+        db (dissoc db :clicked-element)]
+    (cond
+      (and ctrl-key (= (:type element) :handle))
+      (-> db
+          (element.handlers/update-el (:element-id element)
+                                      element.hierarchy/edit-click
+                                      (:id element))
+          (history.handlers/finalize (:timestamp e) [::edit "Edit"]))
+
+      :else
       (-> db
           (element.handlers/clear-ignored)
-          (dissoc :clicked-element)
           (element.handlers/toggle-selection (:id element) shift-key)
           (history.handlers/finalize (:timestamp e)
-                                     [::select-element "Select element"]))
-      (dissoc db :clicked-element))))
+                                     [::select-element "Select element"])))))
 
 (defmethod tool.hierarchy/on-pointer-move [::edit :idle]
   [db e]
@@ -87,7 +93,7 @@
 
       element-id
       (element.handlers/update-el element-id
-                                  element.hierarchy/edit offset id lock?))))
+                                  element.hierarchy/edit-drag offset id lock?))))
 
 (defmethod tool.hierarchy/on-drag-end [::edit :edit]
   [db e]

--- a/src/renderer/tool/impl/base/edit.cljs
+++ b/src/renderer/tool/impl/base/edit.cljs
@@ -93,7 +93,8 @@
 
       element-id
       (element.handlers/update-el element-id
-                                  element.hierarchy/edit-drag offset id lock?))))
+                                  element.hierarchy/edit-drag
+                                  offset id lock?))))
 
 (defmethod tool.hierarchy/on-drag-end [::edit :edit]
   [db e]

--- a/src/renderer/tool/impl/element/path.cljs
+++ b/src/renderer/tool/impl/element/path.cljs
@@ -39,13 +39,6 @@
    [:div (i18n.views/t [::double-click-to-end
                         "Double or right click to finalize the path."])]])
 
-(m/=> next-control-point [:-> [:vector any?] Vec2])
-(defn next-control-point
-  [segments]
-  (let [segment (-> segments utils.path/drop-last-segment last)]
-    (or (utils.path/outgoing-cp segment)
-        (utils.path/segment-point segment :end-point))))
-
 (m/=> adjusted-pointer-position [:-> App Vec2])
 (defn adjusted-pointer-position
   [db]
@@ -103,7 +96,7 @@
             last-segment (last segments)
             out-cp (utils.path/outgoing-cp last-segment)]
         (->> (if out-cp
-               ["C" (first out-cp) (second out-cp) x y x y]
+               ["S" x y x y]
                ["L" x y])
              (conj segments)
              (utils.path/segments->string))))))
@@ -121,9 +114,8 @@
                           (matrix/sub drag-pos))]
     (update-path db #(let [segments (utils.path/string->segments %)]
                        (if (> (count segments) 1)
-                         (let [[ax ay] anchor
-                               [cp1-x cp1-y] (next-control-point segments)]
-                           (->> ["C" cp1-x cp1-y cp2-x cp2-y ax ay]
+                         (let [[ax ay] anchor]
+                           (->> ["S" cp2-x cp2-y ax ay]
                                 (conj (utils.path/drop-last-segment segments))
                                 (utils.path/segments->string)))
                          %)))))


### PR DESCRIPTION
 - Use smooth cubic bezier curves on path creation
 - Allow toggling between cubic and smooth cubic bezier curve on end point double click
 - Render a transparent reflection of the smooth curve control points
 - Fix some snap to angle issues
 - Fix smooth curve translation

https://github.com/user-attachments/assets/078ef724-b53a-42ba-81db-bb295f3b04b8

