### PR TITLE
Enhanced tools

### DIFF
--- a/src/renderer/app/db.cljs
+++ b/src/renderer/app/db.cljs
@@ -45,6 +45,7 @@
    [:cached-tool {:optional true} Tool]
    [:active-pointers {:default {}} [:map-of PointerId PointerEvent]]
    [:pointer-pos {:default [0 0]} Vec2]
+   [:last-origin {:optional true} Vec2]
    [:pointer-offset {:optional true} Vec2]
    [:adjusted-pointer-pos {:default [0 0]} Vec2]
    [:adjusted-pointer-offset {:optional true} Vec2]
@@ -57,7 +58,7 @@
    [:zoom-sensitivity {:default 0.9} [:and number? [:>= 0.01] [:<= 0.99]]]
    [:event-timestamp {:optional true} number?]
    [:features {:optional true} [:set Feature]]
-   [:double-click-delta {:default 250} [:and number? pos?]]
+   [:double-click-delta {:default 300} [:and number? pos?]]
    [:state {:default :idle} State]
    [:cached-state {:optional true} State]
    [:grid {:default false
@@ -82,7 +83,7 @@
    [:recent {:max 10
              :default []
              :persist true} [:vector RecentDocument]]
-   [:drag-threshold {:default 1} number?]
+   [:drag-threshold {:default 2} number?]
    [:system-fonts {:optional true} SystemFonts]
    [:debug-info {:default false
                  :persist true} boolean?]

--- a/src/renderer/input/impl/pointer.cljs
+++ b/src/renderer/input/impl/pointer.cljs
@@ -161,7 +161,7 @@
 
 (defmethod input.hierarchy/pointer "pointerdown"
   [db e]
-  (let [{:keys [nearest-neighbor active-pointers]} db
+  (let [{:keys [active-pointers]} db
         {:keys [button pointer-pos pointer-id]} e]
     (cond-> db
       (not= button :right)
@@ -172,10 +172,11 @@
 
       (or (= button :middle)
           (and (= button :left) (empty? active-pointers)))
-      (assoc :pointer-offset pointer-pos
+      (assoc :pointer-pos pointer-pos
+             :adjusted-pointer-pos (adjusted-pointer-pos db e)
+             :pointer-offset pointer-pos
              :adjusted-pointer-offset (input.handlers/adjusted-pos db
-                                                                   pointer-pos)
-             :nearest-neighbor-offset (:point nearest-neighbor))
+                                                                   pointer-pos))
 
       (or (= button :middle)
           (empty? active-pointers))

--- a/src/renderer/input/impl/pointer.cljs
+++ b/src/renderer/input/impl/pointer.cljs
@@ -62,6 +62,11 @@
   ;; pointer movement.
   (rf/dispatch-sync [::input.events/pointer (->clj el e)]))
 
+(m/=> touch? [:-> PointerEvent boolean?])
+(defn touch?
+  [e]
+  (= (:pointer-type e) "touch"))
+
 (m/=> drag-pointer? [:-> App PointerEvent boolean?])
 (defn drag-pointer?
   [db e]
@@ -161,7 +166,7 @@
 
 (defmethod input.hierarchy/pointer "pointerdown"
   [db e]
-  (let [{:keys [active-pointers]} db
+  (let [{:keys [nearest-neighbor active-pointers]} db
         {:keys [button pointer-pos pointer-id]} e]
     (cond-> db
       (not= button :right)
@@ -177,6 +182,9 @@
              :pointer-offset pointer-pos
              :adjusted-pointer-offset (input.handlers/adjusted-pos db
                                                                    pointer-pos))
+
+      (not (touch? e))
+      (assoc :nearest-neighbor-offset (:point nearest-neighbor))
 
       (or (= button :middle)
           (empty? active-pointers))

--- a/src/renderer/tool/impl/draw/brush.cljs
+++ b/src/renderer/tool/impl/draw/brush.cljs
@@ -69,7 +69,7 @@
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e) [::draw-brush "Draw brush"])
-      (tool.handlers/deactivate)))
+      (tool.handlers/activate ::brush)))
 
 (defmethod tool.hierarchy/render ::brush
   []

--- a/src/renderer/tool/impl/draw/pencil.cljs
+++ b/src/renderer/tool/impl/draw/pencil.cljs
@@ -48,7 +48,7 @@
     (-> db
         (element.handlers/swap path)
         (history.handlers/finalize (:timestamp e) [::draw-line "Draw line"])
-        (tool.handlers/deactivate))))
+        (tool.handlers/activate ::pencil))))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/pencil

--- a/src/renderer/tool/impl/element/circle.cljs
+++ b/src/renderer/tool/impl/element/circle.cljs
@@ -65,7 +65,7 @@
   (update-el db))
 
 (defmethod tool.hierarchy/on-pointer-down [::circle :create]
-  [db e]
+  [db _e]
   (update-el db))
 
 (defmethod tool.hierarchy/on-pointer-move [::circle :create]

--- a/src/renderer/tool/impl/element/circle.cljs
+++ b/src/renderer/tool/impl/element/circle.cljs
@@ -17,8 +17,8 @@
 
 (hierarchy/derive! ::circle ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/on-drag-start [::circle :idle]
-  [db _e]
+(defn create-el
+  [db]
   (let [offset (tool.handlers/snapped-offset db)
         position (tool.handlers/snapped-position db)
         radius (matrix/distance position offset)
@@ -35,19 +35,50 @@
                                        :stroke stroke
                                        :r radius}}))))
 
-(defmethod tool.hierarchy/on-drag [::circle :create]
-  [db _e]
-  (let [offset (tool.handlers/snapped-offset db)
-        position (tool.handlers/snapped-position db)
-        radius (utils.length/->fixed (matrix/distance position offset))]
+(defn update-el
+  [db]
+  (let [position (tool.handlers/snapped-position db)
+        {:keys [cx cy]} (->> db element.handlers/selected first :attrs)
+        radius (-> position
+                   (matrix/sub (element.handlers/parent-offset db))
+                   (matrix/distance [cx cy])
+                   (utils.length/->fixed))]
     (element.handlers/update-selected db #(assoc-in % [:attrs :r] radius))))
 
-(defmethod tool.hierarchy/on-drag-end [::circle :create]
+(defn finalize
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e)
                                  [::create-circle "Create circle"])
       (tool.handlers/deactivate)))
+
+(defmethod tool.hierarchy/on-drag-start [::circle :idle]
+  [db _e]
+  (create-el db))
+
+(defmethod tool.hierarchy/on-pointer-up [::circle :idle]
+  [db _e]
+  (create-el db))
+
+(defmethod tool.hierarchy/on-drag [::circle :create]
+  [db _e]
+  (update-el db))
+
+(defmethod tool.hierarchy/on-pointer-down [::circle :create]
+  [db e]
+  (update-el db))
+
+(defmethod tool.hierarchy/on-pointer-move [::circle :create]
+  [db _e]
+  (update-el db))
+
+(defmethod tool.hierarchy/on-drag-end [::circle :create]
+  [db e]
+  (finalize db e))
+
+(defmethod tool.hierarchy/on-pointer-up [::circle :create]
+  [db e]
+  (finalize db e))
 
 (defmethod tool.hierarchy/snapping-points [::circle :create]
   [db]

--- a/src/renderer/tool/impl/element/ellipse.cljs
+++ b/src/renderer/tool/impl/element/ellipse.cljs
@@ -1,12 +1,14 @@
 (ns renderer.tool.impl.element.ellipse
   "https://www.w3.org/TR/SVG/shapes.html#EllipseElement"
   (:require
+   [clojure.core.matrix :as matrix]
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
+   [renderer.input.handlers :as input.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -15,42 +17,74 @@
 
 (hierarchy/derive! ::ellipse ::tool.hierarchy/element)
 
-(defn attributes
+(defn create-el
   [db]
-  (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
+  (let [fill (document.handlers/attr db :fill)
+        stroke (document.handlers/attr db :stroke)
+        [offset-x offset-y] (tool.handlers/snapped-offset db)
         [x y] (tool.handlers/snapped-position db)
         [rx ry] (->> [(abs (- x offset-x)) (abs (- y offset-y))]
                      (mapv utils.length/->fixed))]
-    {:rx rx
-     :ry ry}))
-
-(defmethod tool.hierarchy/on-drag-start [::ellipse :idle]
-  [db _e]
-  (let [[x y] (tool.handlers/snapped-position db)
-        fill (document.handlers/attr db :fill)
-        stroke (document.handlers/attr db :stroke)]
     (-> db
         (tool.handlers/set-state :create)
         (element.handlers/add {:type :element
                                :tag :ellipse
-                               :attrs (merge (attributes db)
-                                             {:cx x
-                                              :cy y
-                                              :fill fill
-                                              :stroke stroke})}))))
+                               :attrs {:rx rx
+                                       :ry ry
+                                       :cx x
+                                       :cy y
+                                       :fill fill
+                                       :stroke stroke}}))))
 
-(defmethod tool.hierarchy/on-drag [::ellipse :create]
-  [db _e]
-  (let [attrs (attributes db)
-        assoc-attr (fn [el [k v]] (assoc-in el [:attrs k] (str v)))]
-    (element.handlers/update-selected db #(reduce assoc-attr % attrs))))
+(defn update-el
+  [db e]
+  (let [pointer-pos (tool.handlers/snapped-position db)
+        position (matrix/sub pointer-pos (element.handlers/parent-offset db))
+        {:keys [cx cy]} (->> db element.handlers/selected first :attrs)
+        center (mapv utils.length/unit->px [cx cy])
+        position (cond->> position
+                   (input.handlers/snap-to-angle? db e)
+                   (input.handlers/snap-angle center))
+        radius (matrix/sub center position)
+        [rx ry] (mapv (comp utils.length/->fixed abs) radius)]
+    (element.handlers/update-selected db #(-> %
+                                              (assoc-in [:attrs :rx] rx)
+                                              (assoc-in [:attrs :ry] ry)))))
 
-(defmethod tool.hierarchy/on-drag-end [::ellipse :create]
+(defn finalize
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e)
                                  [::create-ellipse "Create ellipse"])
       (tool.handlers/deactivate)))
+
+(defmethod tool.hierarchy/on-drag-start [::ellipse :idle]
+  [db _e]
+  (create-el db))
+
+(defmethod tool.hierarchy/on-pointer-up [::ellipse :idle]
+  [db _e]
+  (create-el db))
+
+(defmethod tool.hierarchy/on-drag [::ellipse :create]
+  [db e]
+  (update-el db e))
+
+(defmethod tool.hierarchy/on-pointer-down [::ellipse :create]
+  [db e]
+  (update-el db e))
+
+(defmethod tool.hierarchy/on-pointer-move [::ellipse :create]
+  [db e]
+  (update-el db e))
+
+(defmethod tool.hierarchy/on-drag-end [::ellipse :create]
+  [db e]
+  (finalize db e))
+
+(defmethod tool.hierarchy/on-pointer-up [::ellipse :create]
+  [db e]
+  (finalize db e))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/ellipse

--- a/src/renderer/tool/impl/element/line.cljs
+++ b/src/renderer/tool/impl/element/line.cljs
@@ -8,6 +8,7 @@
    [renderer.element.handlers :as element.handlers]
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
+   [renderer.input.handlers :as input.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -17,8 +18,8 @@
 
 (hierarchy/derive! ::line ::tool.hierarchy/element)
 
-(defmethod tool.hierarchy/on-drag-start [::line :idle]
-  [db _e]
+(defn create-el
+  [db]
   (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
         [x y] (tool.handlers/snapped-position db)
         stroke (document.handlers/attr db :stroke)]
@@ -32,21 +33,53 @@
                                        :y2 y
                                        :stroke stroke}}))))
 
-(defmethod tool.hierarchy/on-drag [::line :create]
-  [db _e]
-  (let [position (tool.handlers/snapped-position db)
-        [x y] (->> (element.handlers/parent-offset db)
-                   (matrix/sub position)
-                   (mapv utils.length/->fixed))]
+(defn update-el
+  [db e]
+  (let [pointer-pos (tool.handlers/snapped-position db)
+        end-pos (matrix/sub pointer-pos (element.handlers/parent-offset db))
+        {:keys [x1 y1]} (->> db element.handlers/selected first :attrs)
+        start-pos (mapv utils.length/unit->px [x1 y1])
+        end-pos (cond->> end-pos
+                  (input.handlers/snap-to-angle? db e)
+                  (input.handlers/snap-angle start-pos))
+        [x2 y2] (mapv utils.length/->fixed end-pos)]
     (element.handlers/update-selected db #(-> %
-                                              (assoc-in [:attrs :x2] x)
-                                              (assoc-in [:attrs :y2] y)))))
+                                              (assoc-in [:attrs :x2] x2)
+                                              (assoc-in [:attrs :y2] y2)))))
 
-(defmethod tool.hierarchy/on-drag-end [::line :create]
+(defn finalize
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e) [::create-line "Create line"])
       (tool.handlers/deactivate)))
+
+(defmethod tool.hierarchy/on-drag-start [::line :idle]
+  [db _e]
+  (create-el db))
+
+(defmethod tool.hierarchy/on-pointer-up [::line :idle]
+  [db _e]
+  (create-el db))
+
+(defmethod tool.hierarchy/on-drag [::line :create]
+  [db e]
+  (update-el db e))
+
+(defmethod tool.hierarchy/on-pointer-down [::line :create]
+  [db e]
+  (update-el db e))
+
+(defmethod tool.hierarchy/on-pointer-move [::line :create]
+  [db e]
+  (update-el db e))
+
+(defmethod tool.hierarchy/on-drag-end [::line :create]
+  [db e]
+  (finalize db e))
+
+(defmethod tool.hierarchy/on-pointer-up [::line :create]
+  [db e]
+  (finalize db e))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/line

--- a/src/renderer/tool/impl/element/poly.cljs
+++ b/src/renderer/tool/impl/element/poly.cljs
@@ -44,12 +44,9 @@
 
     (input.handlers/snap-to-angle? db e)
     (input.handlers/snap-angle (->> (element.handlers/selected db)
-                                    (first)
-                                    :attrs
-                                    :points
+                                    first :attrs :points
                                     (utils.attribute/points->vec)
-                                    (pop)
-                                    (peek)
+                                    pop peek
                                     (mapv utils.length/unit->px)))
 
     :always
@@ -60,10 +57,6 @@
   (update-points db #(->> (adjusted-pointer-position db e)
                           (into [%])
                           (string/join " "))))
-
-(defmethod tool.hierarchy/on-drag-end [::tool.hierarchy/poly :idle]
-  [db e]
-  (tool.hierarchy/on-pointer-up db e))
 
 (defmethod tool.hierarchy/on-drag-end [::tool.hierarchy/poly :create]
   [db e]
@@ -85,3 +78,11 @@
                         (->> (concat point-vector point)
                              (flatten)
                              (string/join " ")))))))
+
+(defmethod tool.hierarchy/on-drag-start [::tool.hierarchy/poly :idle]
+  [db e]
+  (tool.hierarchy/on-pointer-up db e))
+
+(defmethod tool.hierarchy/on-drag [::tool.hierarchy/poly :create]
+  [db e]
+  (tool.hierarchy/on-pointer-move db e))

--- a/src/renderer/tool/impl/element/rect.cljs
+++ b/src/renderer/tool/impl/element/rect.cljs
@@ -1,12 +1,14 @@
 (ns renderer.tool.impl.element.rect
   "https://www.w3.org/TR/SVG/shapes.html#RectElement"
   (:require
+   [clojure.core.matrix :as matrix]
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
    [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
+   [renderer.input.handlers :as input.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -16,43 +18,90 @@
 
 (hierarchy/derive! ::rect ::tool.hierarchy/element)
 
-(defn attributes
+(defn create-el
   [db]
-  (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
-        [x y] (tool.handlers/snapped-position db)
-        [width height] (mapv abs [(- x offset-x) (- y offset-y)])]
-    {:x (utils.length/->fixed (cond-> offset-x (< x offset-x) (- width)))
-     :y (utils.length/->fixed (cond-> offset-y (< y offset-y) (- height)))
-     :width (utils.length/->fixed width)
-     :height (utils.length/->fixed height)}))
-
-(defmethod tool.hierarchy/on-drag-start [::rect :idle]
-  [db _e]
   (let [fill (document.handlers/attr db :fill)
-        stroke (document.handlers/attr db :stroke)]
+        stroke (document.handlers/attr db :stroke)
+        parent-offset (element.handlers/parent-offset db)
+        [offset-x offset-y] (tool.handlers/snapped-offset db)
+        [x y] (tool.handlers/snapped-position db)
+        [width height] (mapv (comp utils.length/->fixed abs)
+                             [(- x offset-x) (- y offset-y)])
+        x (cond-> offset-x (< x offset-x) (- width))
+        y (cond-> offset-y (< y offset-y) (- height))
+        [x y] (mapv utils.length/->fixed [x y])
+        new-origin (matrix/sub (tool.handlers/snapped-position db)
+                               parent-offset)]
     (-> db
+        (assoc :last-origin new-origin)
         (tool.handlers/set-state :create)
+        (assoc :last-origin new-origin)
         (element.handlers/add {:type :element
                                :tag :rect
-                               :attrs (merge (attributes db)
-                                             {:fill fill
-                                              :stroke stroke})}))))
+                               :attrs {:x x
+                                       :y y
+                                       :width width
+                                       :height height
+                                       :fill fill
+                                       :stroke stroke}}))))
 
-(defmethod tool.hierarchy/on-drag [::rect :create]
-  [db _e]
-  (let [attrs (attributes db)
-        assoc-attr (fn [el [k v]] (assoc-in el [:attrs k] (str v)))
-        [min-x min-y] (element.handlers/parent-offset db)]
-    (-> db
-        (element.handlers/update-selected #(reduce assoc-attr % attrs))
-        (element.handlers/translate [(- min-x) (- min-y)]))))
+(defn update-el
+  [db e]
+  (let [pointer-pos (tool.handlers/snapped-position db)
+        position (matrix/sub pointer-pos (element.handlers/parent-offset db))
+        origin (:last-origin db)
+        position (cond->> position
+                   (input.handlers/snap-to-angle? db e)
+                   (input.handlers/snap-angle origin))
+        size (matrix/sub position origin)
+        [w h] (mapv (comp utils.length/->fixed abs) size)
+        new-x (cond-> (first origin)
+                (neg? (first size))
+                (+ (first size)))
+        new-y (cond-> (second origin)
+                (neg? (second size))
+                (+ (second size)))
+        [new-x new-y] (mapv utils.length/->fixed [new-x new-y])]
+    (element.handlers/update-selected db #(-> %
+                                              (assoc-in [:attrs :x] new-x)
+                                              (assoc-in [:attrs :y] new-y)
+                                              (assoc-in [:attrs :width] w)
+                                              (assoc-in [:attrs :height] h)))))
 
-(defmethod tool.hierarchy/on-drag-end [::rect :create]
+(defn finalize
   [db e]
   (-> db
       (history.handlers/finalize (:timestamp e)
                                  [::create-rectangle "Create rectangle"])
       (tool.handlers/deactivate)))
+
+(defmethod tool.hierarchy/on-drag-start [::rect :idle]
+  [db _e]
+  (create-el db))
+
+(defmethod tool.hierarchy/on-pointer-up [::rect :idle]
+  [db _e]
+  (create-el db))
+
+(defmethod tool.hierarchy/on-drag [::rect :create]
+  [db e]
+  (update-el db e))
+
+(defmethod tool.hierarchy/on-pointer-down [::rect :create]
+  [db e]
+  (update-el db e))
+
+(defmethod tool.hierarchy/on-pointer-move [::rect :create]
+  [db e]
+  (update-el db e))
+
+(defmethod tool.hierarchy/on-drag-end [::rect :create]
+  [db e]
+  (finalize db e))
+
+(defmethod tool.hierarchy/on-pointer-up [::rect :create]
+  [db e]
+  (finalize db e))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/rect

--- a/src/renderer/tool/impl/element/rect.cljs
+++ b/src/renderer/tool/impl/element/rect.cljs
@@ -22,20 +22,16 @@
   [db]
   (let [fill (document.handlers/attr db :fill)
         stroke (document.handlers/attr db :stroke)
-        parent-offset (element.handlers/parent-offset db)
         [offset-x offset-y] (tool.handlers/snapped-offset db)
         [x y] (tool.handlers/snapped-position db)
         [width height] (mapv (comp utils.length/->fixed abs)
                              [(- x offset-x) (- y offset-y)])
-        x (cond-> offset-x (< x offset-x) (- width))
-        y (cond-> offset-y (< y offset-y) (- height))
-        [x y] (mapv utils.length/->fixed [x y])
-        new-origin (matrix/sub (tool.handlers/snapped-position db)
-                               parent-offset)]
+        origin [(cond-> offset-x (< x offset-x) (- width))
+                (cond-> offset-y (< y offset-y) (- height))]
+        [x y] (mapv utils.length/->fixed origin)]
     (-> db
-        (assoc :last-origin new-origin)
+        (assoc :last-origin origin)
         (tool.handlers/set-state :create)
-        (assoc :last-origin new-origin)
         (element.handlers/add {:type :element
                                :tag :rect
                                :attrs {:x x
@@ -48,8 +44,9 @@
 (defn update-el
   [db e]
   (let [pointer-pos (tool.handlers/snapped-position db)
-        position (matrix/sub pointer-pos (element.handlers/parent-offset db))
-        origin (:last-origin db)
+        parent-offset (element.handlers/parent-offset db)
+        position (matrix/sub pointer-pos parent-offset)
+        origin (matrix/sub (:last-origin db) parent-offset)
         position (cond->> position
                    (input.handlers/snap-to-angle? db e)
                    (input.handlers/snap-angle origin))


### PR DESCRIPTION
- Circle, rect, ellipse, line, polygon, polyline tools now create elements on drag and also subsequent click events
- Various pointer event and snap fixes on touch devices
- Draw tools (pen and brush) remain active after creating a shape
- Tweaked value of `double-click-delta` and `drag-threshold` to enhance input behavior