### PR TITLE
Centroid enhancements

### DIFF
--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -842,4 +842,7 @@
  {:transform "تحويل"}
 
  :renderer.tool.impl.misc.core
- {:misc "متنوع"}}
+ {:misc "متنوع"}
+
+ :renderer.utils.element
+ {:centroid "مركز ثقل"}}

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -890,4 +890,7 @@
  {:transform "Transformieren"}
 
  :renderer.tool.impl.misc.core
- {:misc "Verschiedenes"}}
+ {:misc "Verschiedenes"}
+
+ :renderer.utils.element
+ {:centroid "Schwerpunkt"}}

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -892,4 +892,7 @@
  {:transform "Μετασχηματισμός"}
 
  :renderer.tool.impl.misc.core
- {:misc "Διάφορα"}}
+ {:misc "Διάφορα"}
+
+ :renderer.utils.element
+ {:centroid "κεντροειδές"}}

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -855,4 +855,7 @@
  {:transform "Transform"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscallaneous"}}
+ {:misc "Miscallaneous"}
+
+ :renderer.utils.element
+ {:centroid "centroid"}}

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -874,4 +874,7 @@
  {:transform "Transformar"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscelánea"}}
+ {:misc "Miscelánea"}
+
+ :renderer.utils.element
+ {:centroid "centroide"}}

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -881,4 +881,7 @@
  {:transform "Transformer"}
 
  :renderer.tool.impl.misc.core
- {:misc "Divers"}}
+ {:misc "Divers"}
+
+ :renderer.utils.element
+ {:centroid "centroïde"}}

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -884,4 +884,7 @@
  {:transform "Trasforma"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscallaneous"}}
+ {:misc "Miscallaneous"}
+
+ :renderer.utils.element
+ {:centroid "centroide"}}

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -826,4 +826,7 @@
  {:transform "変形"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscallaneous"}}
+ {:misc "Miscallaneous"}
+
+ :renderer.utils.element
+ {:centroid "重心"}}

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -821,4 +821,7 @@
  {:transform "변형"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscallaneous"}}
+ {:misc "Miscallaneous"}
+
+ :renderer.utils.element
+ {:centroid "무게중심"}}

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -885,4 +885,7 @@
  {:transform "Transformeren"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscallaneous"}}
+ {:misc "Miscallaneous"}
+
+ :renderer.utils.element
+ {:centroid "centroïde"}}

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -867,4 +867,7 @@
  {:transform "Transformar"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscallaneous"}}
+ {:misc "Miscallaneous"}
+
+ :renderer.utils.element
+ {:centroid "centroide"}}

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -868,4 +868,7 @@
  {:transform "Трансформация"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscallaneous"}}
+ {:misc "Miscallaneous"}
+
+ :renderer.utils.element
+ {:centroid "центроид"}}

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -869,4 +869,7 @@
  {:transform "Transformera"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscallaneous"}}
+ {:misc "Miscallaneous"}
+
+ :renderer.utils.element
+ {:centroid "centroid"}}

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -863,4 +863,7 @@
  {:transform "Dönüştür"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscallaneous"}}
+ {:misc "Miscallaneous"}
+
+ :renderer.utils.element
+ {:centroid "ağırlık merkezi"}}

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -787,4 +787,7 @@
  {:transform "变形"}
 
  :renderer.tool.impl.misc.core
- {:misc "Miscallaneous"}}
+ {:misc "Miscallaneous"}
+
+ :renderer.utils.element
+ {:centroid "质心"}}

--- a/src/renderer/element/impl/custom/blob.cljs
+++ b/src/renderer/element/impl/custom/blob.cljs
@@ -136,9 +136,10 @@
 
 (defmethod element.hierarchy/centroid :blob
   [el]
-  (let [{{:keys [x y size]} :attrs} el
+  (let [offset (utils.element/offset el)
+        {{:keys [x y size]} :attrs} el
         [x y size] (mapv utils.length/unit->px [x y size])]
-    (matrix/add [x y] (/ size 2))))
+    (matrix/add [x y] (/ size 2) offset)))
 
 (defmethod element.hierarchy/path :blob
   [el]

--- a/src/renderer/element/impl/shape/poly.cljs
+++ b/src/renderer/element/impl/shape/poly.cljs
@@ -115,6 +115,9 @@
 
 (defmethod element.hierarchy/centroid ::element.hierarchy/poly
   [el]
+  ;; Calculates the centroid of a polygon using an extension of the Shoelace
+  ;; Formula. This method works for both convex and concave polygons, but not
+  ;; for self-intersecting ones.
   (let [offset (utils.element/offset el)
         vertices (->vertices el)
         count-v (count vertices)

--- a/src/renderer/element/impl/shape/poly.cljs
+++ b/src/renderer/element/impl/shape/poly.cljs
@@ -115,13 +115,27 @@
 
 (defmethod element.hierarchy/centroid ::element.hierarchy/poly
   [el]
-  (let [vertices (->vertices el)]
-    (-> (reduce matrix/add [0 0] vertices)
-        (matrix/div (count vertices)))))
+  (let [offset (utils.element/offset el)
+        vertices (->vertices el)
+        count-v (count vertices)
+        [cx cy cross-sum] (reduce-kv
+                           (fn [[cx cy s] index [x1 y1]]
+                             (let [[x2 y2] (if (= index (dec count-v))
+                                             (first vertices)
+                                             (nth vertices (inc index)))
+                                   cross (- (* x1 y2) (* x2 y1))]
+                               [(+ cx (* (+ x1 x2) cross))
+                                (+ cy (* (+ y1 y2) cross))
+                                (+ s cross)]))
+                           [0 0 0]
+                           vertices)
+        denom (* 3 cross-sum)]
+    (matrix/add [(/ cx denom) (/ cy denom)]
+                offset)))
 
 (defmethod element.hierarchy/snapping-points ::element.hierarchy/poly
   [el]
-  (->vertices el))
+  (mapv #(with-meta % {:label [::point "point"]}) (->vertices el)))
 
 (defmethod element.hierarchy/delete-segments ::element.hierarchy/poly
   [el]

--- a/src/renderer/tool/impl/base/edit/core.cljs
+++ b/src/renderer/tool/impl/base/edit/core.cljs
@@ -1,6 +1,5 @@
 (ns renderer.tool.impl.base.edit.core
   (:require
-   [clojure.core.matrix :as matrix]
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
    [renderer.element.handlers :as element.handlers]
@@ -16,7 +15,6 @@
    [renderer.tool.impl.base.edit.type]
    [renderer.tool.subs :as-alias tool.subs]
    [renderer.tool.views :as tool.views]
-   [renderer.utils.element :as utils.element]
    [renderer.utils.key :as utils.key]
    [renderer.utils.svg :as utils.svg]))
 
@@ -42,11 +40,9 @@
                    (->> (element.hierarchy/handles el)
                         (map (fn [handle] [tool.views/handle handle]))
                         (into [:g]))
-                   (when-let [pos (element.hierarchy/centroid el)]
-                     (let [offset (utils.element/offset el)
-                           pos (matrix/add offset pos)]
-                       [utils.svg/dot pos
-                        [:title (i18n.views/t [::centroid "Centroid"])]]))]))
+                   (when-let [centroid (element.hierarchy/centroid el)]
+                     [utils.svg/dot centroid
+                      [:title (i18n.views/t [::centroid "Centroid"])]])]))
            (into [:g [element.hierarchy/render select-box]])))))
 
 (rf/dispatch [::action.events/register-action

--- a/src/renderer/utils/element.cljs
+++ b/src/renderer/utils/element.cljs
@@ -79,10 +79,14 @@
 (defn acc-snapping-points
   [el options]
   (let [points (or (when (contains? options :nodes)
-                     (mapv #(with-meta
-                              (matrix/add % (offset el))
-                              (merge (meta %) {:id (:id el)}))
-                           (element.hierarchy/snapping-points el)))
+                     (let [centroid (element.hierarchy/centroid el)]
+                       (mapv #(with-meta
+                                (matrix/add % (offset el))
+                                (merge (meta %) {:id (:id el)}))
+                             (cond-> (element.hierarchy/snapping-points el)
+                               centroid
+                               (conj (with-meta centroid
+                                       {:label [::centroid "centroid"]}))))))
                    [])]
     (cond-> points
       (:bbox el)


### PR DESCRIPTION
- Use an extension of the Shoelace Formula to calculate the centroid of polygons and polylines. We previously used the mean of vertices, that works for triangles only. The updated calculation does not solve self-intersecting polygons, that require a more complex approach.
- Add the centroid to snapping points, when it is defined.

Resolves #38