### PR TITLE
Improve path editing performance

### DIFF
--- a/src/renderer/attribute/impl/d.cljs
+++ b/src/renderer/attribute/impl/d.cljs
@@ -6,7 +6,6 @@
    [renderer.attribute.hierarchy :as attribute.hierarchy]
    [renderer.attribute.views :as attribute.views]
    [renderer.document.events :as-alias document.events]
-   [renderer.document.subs :as-alias document.subs]
    [renderer.element.events :as-alias element.events]
    [renderer.element.handlers :as element.handlers]
    [renderer.element.hierarchy :as-alias element.hierarchy]
@@ -81,11 +80,13 @@
   (let [new-v (.. e -target -value)]
     (if (or (string/blank? new-v) (js/isNaN new-v))
       (set! (.. e -target -value) value)
-      (let [updated-d (-> d
-                          (utils.path/string->segments)
-                          (assoc-in [index field-index] new-v)
-                          (utils.path/segments->string))]
-        (rf/dispatch [::element.events/set-attr :d updated-d])))))
+      (let [segments (utils.path/string->segments d)
+            new-seg (.slice (aget segments index))]
+        (aset new-seg field-index new-v)
+        (let [new-segs (.slice segments)]
+          (aset new-segs index new-seg)
+          (rf/dispatch [::element.events/set-attr :d
+                        (utils.path/segments->string new-segs)]))))))
 
 (defn segment-input
   [{:keys [d index]} {:keys [field-index value id]}]
@@ -171,11 +172,10 @@
 
 (defn segment-row
   [{:keys [el-id index segment d selected-handles]}]
-  (let [hovered-ids @(rf/subscribe [::document.subs/hovered-ids])
-        command (first segment)
+  (let [command (first segment)
         {:keys [label url]} (->command command)
         id (segment-id index)
-        hovered? (segment-active? hovered-ids index)
+        hovered? @(rf/subscribe [::element.subs/hovered? id])
         selected? (segment-active? selected-handles index)]
     [:div.flex.flex-col.gap-px
      {:on-pointer-enter #(rf/dispatch [::document.events/set-hovered-id id])
@@ -221,6 +221,7 @@
      [attribute.views/heading "d" tag :d]
      (->> segments
           (map-indexed (fn [index segment]
+                         ^{:key index}
                          [segment-row {:el-id id
                                        :index index
                                        :segment segment

--- a/src/renderer/db.cljs
+++ b/src/renderer/db.cljs
@@ -50,8 +50,6 @@
    "A" "a"
    "Z" "z"])
 
-(def PathSegment
-  [:cat PathCommand [:* number?]])
+(def PathSegment JS_Array)
 
-(def PathSegments
-  [:vector PathSegment])
+(def PathSegments JS_Array)

--- a/src/renderer/element/handlers.cljs
+++ b/src/renderer/element/handlers.cljs
@@ -1031,7 +1031,7 @@
   ([db el-id]
    (assoc-in db (path db el-id :selected-handles) #{})))
 
-(m/=> toggle-handle-selection [:-> App HandleId boolean? App])
+(m/=> toggle-handle-selection [:-> App ElementId HandleId boolean? App])
 (defn toggle-handle-selection
   [db el-id handle-id additive]
   (if additive

--- a/src/renderer/element/impl/shape/path.cljs
+++ b/src/renderer/element/impl/shape/path.cljs
@@ -83,7 +83,7 @@
 
       "S"
       [:<>
-       (when-let [implied-cp1 (some-> (get segments (dec index))
+       (when-let [implied-cp1 (some-> (aget segments (dec index))
                                       utils.path/outgoing-cp
                                       (matrix/add offset))]
          [utils.svg/arm prev-ep implied-cp1])
@@ -121,7 +121,7 @@
 
       "S"
       (let [cp0 (->px-point segment :start-control-point)
-            implied-cp1 (some-> (get segments (dec index))
+            implied-cp1 (some-> (aget segments (dec index))
                                 utils.path/outgoing-cp
                                 (->> (mapv utils.length/unit->px)))]
         (cond-> [{:point-type :end-point
@@ -162,15 +162,16 @@
                (let [label (-> (utils.path/segment->command segment)
                                (attribute.impl.d/path-commands)
                                :label)]
-                 {:id (keyword index point-type)
-                  :position (matrix/add offset pos)
-                  :label label
-                  :cursor cursor
-                  :type :handle
-                  :action :edit
-                  :implied (boolean implied)
-                  :rounded (boolean rounded)
-                  :parent parent})))))
+                 (cond-> {:id (keyword index point-type)
+                          :position (matrix/add offset pos)
+                          :label label
+                          :type :handle
+                          :action :edit
+                          :implied (boolean implied)
+                          :rounded (boolean rounded)
+                          :parent parent}
+                   cursor
+                   (assoc :cursor cursor)))))))
 
 (m/=> acc-endpoints [:-> PathSegments [:vector Vec2]])
 (defn acc-endpoints
@@ -184,26 +185,29 @@
 (defn c->s-segment
   [segment]
   (let [[_ _cp1x _cp1y cp2x cp2y x y] segment]
-    ["S" cp2x cp2y x y]))
+    #js ["S" cp2x cp2y x y]))
 
 (m/=> s->c-segment [:-> PathSegments int? PathSegment])
 (defn s->c-segment
   [segments index]
-  (let [[_ cp2x cp2y x y] (get segments index)
-        prev-segment (get segments (dec index))
+  (let [[_ cp2x cp2y x y] (aget segments index)
+        prev-segment (aget segments (dec index))
         endpoints (acc-endpoints segments)
         prev-ep (get endpoints (dec index))
         [cp1x cp1y] (or (utils.path/outgoing-cp prev-segment) prev-ep)]
-    ["C" cp1x cp1y cp2x cp2y x y]))
+    #js ["C" cp1x cp1y cp2x cp2y x y]))
 
 (m/=> toggle-shorthand [:-> PathSegments int? PathSegments])
 (defn toggle-shorthand
   [segments index]
-  (let [segment (get segments index)
-        command (utils.path/segment->command segment)]
-    (case command
-      "C" (assoc segments index (c->s-segment segment))
-      "S" (assoc segments index (s->c-segment segments index))
+  (let [segment (aget segments index)
+        command (utils.path/segment->command segment)
+        new-seg (case command
+                  "C" (c->s-segment segment)
+                  "S" (s->c-segment segments index)
+                  nil)]
+    (if new-seg
+      (doto (.slice segments) (aset index new-seg))
       segments)))
 
 (defmethod element.hierarchy/handle-click :path
@@ -250,39 +254,39 @@
                            PathSegment])
 (defn translate-seg-point
   [segments index point-type delta]
-  (let [segment (get segments index)
+  (let [segment (aget segments index)
         [dx dy] delta
         cmd (utils.path/segment->command segment)]
     (case cmd
       "H"
-      (cond-> segments
-        (= point-type :end-point)
-        (assoc index (assoc segment 1 (-> (second segment)
-                                          (utils.length/transform + dx)))))
+      (if (= point-type :end-point)
+        (let [new-seg (.slice segment)]
+          (aset new-seg 1 (utils.length/transform (aget segment 1) + dx))
+          (doto (.slice segments) (aset index new-seg)))
+        segments)
 
       "V"
-      (cond-> segments
-        (= point-type :end-point)
-        (assoc index (assoc segment 1 (-> (second segment)
-                                          (utils.length/transform + dy)))))
+      (if (= point-type :end-point)
+        (let [new-seg (.slice segment)]
+          (aset new-seg 1 (utils.length/transform (aget segment 1) + dy))
+          (doto (.slice segments) (aset index new-seg)))
+        segments)
 
       (let [[xi yi] (utils.path/point-indices cmd point-type)]
-        (cond-> segments
-          (and xi yi)
-          (assoc index
-                 (assoc segment
-                        xi (-> (get segment xi)
-                               (utils.length/transform + dx))
-                        yi (-> (get segment yi)
-                               (utils.length/transform + dy)))))))))
+        (if (and xi yi)
+          (let [new-seg (.slice segment)]
+            (aset new-seg xi (utils.length/transform (aget segment xi) + dx))
+            (aset new-seg yi (utils.length/transform (aget segment yi) + dy))
+            (doto (.slice segments) (aset index new-seg)))
+          segments)))))
 
 (m/=> translate-point [:-> int? PathPointType Vec2 PathSegments PathSegments])
 (defn translate-point
   [index point-type delta segments]
   (let [segments (translate-seg-point segments index point-type delta)]
     (if (= point-type :end-point)
-      (let [cmd (utils.path/segment->command (get segments index))
-            next-cmd (utils.path/segment->command (get segments (inc index)))]
+      (let [cmd (utils.path/segment->command (aget segments index))
+            next-cmd (utils.path/segment->command (aget segments (inc index)))]
         (cond-> segments
           (= cmd "C")
           (translate-seg-point index :end-control-point delta)
@@ -297,11 +301,11 @@
 (defn snap-control-point-to-angle
   [segments index point-type offset]
   (let [endpoints (acc-endpoints segments)
-        cmd (utils.path/segment->command (get segments index))
+        cmd (utils.path/segment->command (aget segments index))
         anchor (if (and (= point-type :start-control-point) (not= cmd "S"))
                  (get endpoints (dec index))
                  (get endpoints index))
-        cp-pos (->px-point (get segments index) point-type)
+        cp-pos (->px-point (aget segments index) point-type)
         new-cp-pos (matrix/add cp-pos offset)
         snapped (input.handlers/snap-angle anchor new-cp-pos)]
     (matrix/sub snapped cp-pos)))

--- a/src/renderer/tool/impl/element/path.cljs
+++ b/src/renderer/tool/impl/element/path.cljs
@@ -94,13 +94,13 @@
      db
      #(let [segments (-> (utils.path/string->segments %)
                          (utils.path/drop-last-segment))
-            last-segment (last segments)
+            last-segment (aget segments (dec (count segments)))
             out-cp (utils.path/outgoing-cp last-segment)]
-        (->> (if out-cp
-               ["S" x y x y]
-               ["L" x y])
-             (conj segments)
-             (utils.path/segments->string))))))
+        (-> segments
+            (.concat #js [(if out-cp
+                            #js ["S" x y x y]
+                            #js ["L" x y])])
+            (utils.path/segments->string))))))
 
 (defmethod tool.hierarchy/on-pointer-up [::path :create]
   [db _e]
@@ -116,9 +116,9 @@
     (update-path db #(let [segments (utils.path/string->segments %)]
                        (if (> (count segments) 1)
                          (let [[ax ay] (mapv utils.length/->fixed anchor)]
-                           (->> ["S" cp2-x cp2-y ax ay]
-                                (conj (utils.path/drop-last-segment segments))
-                                (utils.path/segments->string)))
+                           (-> (utils.path/drop-last-segment segments)
+                               (.concat #js [#js ["S" cp2-x cp2-y ax ay]])
+                               (utils.path/segments->string)))
                          %)))))
 
 (defmethod tool.hierarchy/on-drag-end [::path :create]

--- a/src/renderer/utils/path.cljs
+++ b/src/renderer/utils/path.cljs
@@ -30,7 +30,7 @@
       :reverse (.reverse path))
     (get-d path)))
 
-(m/=> point-indices [:-> string? PathPointType [:maybe Vec2]])
+(m/=> point-indices [:-> [:maybe string?] PathPointType [:maybe Vec2]])
 (defn point-indices
   "Returns the vector indices if the point-type is defined for the command.
    https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/d#path_commands"
@@ -101,21 +101,22 @@
 (m/=> string->segments [:-> [:maybe string?] [:maybe PathSegments]])
 (defn string->segments
   [d]
-  (some-> d svgpath .abs .-segments js->clj))
+  (some-> d svgpath .abs .-segments))
 
 (m/=> segments->string [:-> PathSegments string?])
 (defn segments->string
   [segments]
   (->> segments
-       (flatten)
+       (map #(string/join " " %))
        (string/join " ")))
 
 (m/=> drop-last-segment [:-> PathSegments PathSegments])
 (defn drop-last-segment
   [segments]
-  (cond-> segments
-    (> (count segments) 1)
-    pop))
+  (let [n (count segments)]
+    (if (> n 1)
+      (.slice segments 0 (dec n))
+      segments)))
 
 (m/=> boolean-operation [:-> string? string? BooleanOperation string?])
 (defn boolean-operation

--- a/test/utils/path_test.cljs
+++ b/test/utils/path_test.cljs
@@ -1,45 +1,40 @@
 (ns utils.path-test
   (:require
    [cljs.test :refer-macros [deftest testing are]]
+   [goog.object]
    [renderer.utils.path :as utils.path]))
 
 (deftest test-segment->command
   (testing "getting a path command from a segment"
     (are [x y] (= x y)
       nil (utils.path/segment->command nil)
-      "M" (utils.path/segment->command ["M" 10 10])
-      "M" (utils.path/segment->command ["m" 10 10])
-      "L" (utils.path/segment->command ["l" 20 20]))))
+      "M" (utils.path/segment->command #js ["M" 10 10])
+      "M" (utils.path/segment->command #js ["m" 10 10])
+      "L" (utils.path/segment->command #js ["l" 20 20]))))
 
 (deftest test-segment-point
   (testing "getting a position for a segment and point type"
     (are [x y] (= x y)
       nil (utils.path/segment-point nil :end-point)
-      [10 10] (utils.path/segment-point ["M" 10 10] :end-point)
-      [20 20] (utils.path/segment-point ["C" 5 5 15 15 20 20] :end-point)
-      [5 5] (utils.path/segment-point ["C" 5 5 15 15 20 20]
+      [10 10] (utils.path/segment-point #js ["M" 10 10] :end-point)
+      [20 20] (utils.path/segment-point #js ["C" 5 5 15 15 20 20] :end-point)
+      [5 5] (utils.path/segment-point #js ["C" 5 5 15 15 20 20]
                                       :start-control-point))))
 
 (deftest test-string->segments
   (testing "parsing path data string into segments"
-    (are [x y] (= x y)
+    (are [x y] (= (js->clj x) (js->clj y))
       nil (utils.path/string->segments nil)
-      [] (utils.path/string->segments "")
-      [["M" 10 10]] (utils.path/string->segments "M10 10")
-      [["M" 10 10] ["L" 20 20]] (utils.path/string->segments "M10 10 L20 20"))))
-
-(deftest test-segments->string
-  (testing "converting segments back to path data string"
-    (are [x y] (= x y)
-      "" (utils.path/segments->string [])
-      "M 10 10" (utils.path/segments->string [["M" 10 10]])
-      "M 10 10 L 20 20 z" (utils.path/segments->string [["M" 10 10]
-                                                        ["L" 20 20]
-                                                        ["z"]]))))
+      [] (into [] (utils.path/string->segments ""))
+      #js [#js ["M" 10 10]] (utils.path/string->segments "M10 10")
+      #js [#js ["M" 10 10]
+           #js ["L" 20 20]] (utils.path/string->segments "M10 10 L20 20"))))
 
 (deftest test-drop-last-segment
   (testing "dropping the last segment from segments vector"
-    (are [x y] (= x y)
-      [] (utils.path/drop-last-segment [])
-      [["M" 10 10]] (utils.path/drop-last-segment [["M" 10 10]])
-      [["M" 10 10]] (utils.path/drop-last-segment [["M" 10 10] ["L" 20 20]]))))
+    (are [x y] (= (js->clj x) (js->clj y))
+      #js [] (utils.path/drop-last-segment #js [])
+      #js [#js ["M" 10 10]] (utils.path/drop-last-segment #js [#js ["M" 10 10]])
+      #js [#js ["M" 10 10]] (utils.path/drop-last-segment
+                             #js [#js ["M" 10 10]
+                                  #js ["L" 20 20]]))))


### PR DESCRIPTION
Use `aget` and `aset` to transform path segments, in order to avoid `js->clj` transformations on the editing hot path. This is far from idiomatic Clojure, but we really had to improve the performance of path editing.