### PR TITLE
Enhance element to path conversions

### DIFF
--- a/src/renderer/element/impl/custom/brush.cljs
+++ b/src/renderer/element/impl/custom/brush.cljs
@@ -176,7 +176,9 @@
 
 (defmethod element.hierarchy/path :brush
   [el]
-  (points->path (-> el :attrs :points) (select-keys (:attrs el) option-keys)))
+  (let [options (select-keys (:attrs el) option-keys)]
+    (-> el :attrs :points
+        (points->path options))))
 
 (defmethod element.hierarchy/handles :brush
   [el]

--- a/src/renderer/element/impl/shape/circle.cljs
+++ b/src/renderer/element/impl/shape/circle.cljs
@@ -10,6 +10,7 @@
    [renderer.utils.bounds :as utils.bounds]
    [renderer.utils.element :as utils.element]
    [renderer.utils.length :as utils.length]
+   [renderer.utils.math :as utils.math]
    [renderer.utils.svg :as utils.svg]))
 
 (hierarchy/derive! :circle ::element.hierarchy/shape)
@@ -61,12 +62,16 @@
 (defmethod element.hierarchy/path :circle
   [el]
   (let [{{:keys [cx cy r]} :attrs} el
-        [cx cy r] (map utils.length/unit->px [cx cy r])]
-    (string/join " " ["M" (+ cx r) cy
-                      "A" r r 0 0 1 cx (+ cy r)
-                      "A" r r 0 0 1 (- cx r) cy
-                      "A" r r 0 0 1 (+ cx r) cy
-                      "z"])))
+        [cx cy r] (map utils.length/unit->px [cx cy r])
+        kr (* utils.math/KAPPA r)]
+    (->> ["M" (+ cx r) cy
+          "C" (+ cx r) (+ cy kr) (+ cx kr) (+ cy r) cx (+ cy r)
+          "S" (- cx r) (+ cy kr) (- cx r) cy
+          "S" (- cx kr) (- cy r) cx (- cy r)
+          "S" (+ cx r) (- cy kr) (+ cx r) cy
+          "z"]
+         (map #(cond-> % (number? %) utils.length/->fixed))
+         (string/join " "))))
 
 (defmethod element.hierarchy/handle-drag :circle
   [el [x _y] handle _lock?]

--- a/src/renderer/element/impl/shape/ellipse.cljs
+++ b/src/renderer/element/impl/shape/ellipse.cljs
@@ -10,6 +10,7 @@
    [renderer.utils.bounds :as utils.bounds]
    [renderer.utils.element :as utils.element]
    [renderer.utils.length :as utils.length]
+   [renderer.utils.math :as utils.math]
    [renderer.utils.svg :as utils.svg]))
 
 (hierarchy/derive! :ellipse ::element.hierarchy/shape)
@@ -59,12 +60,16 @@
   (let [{{:keys [cx cy rx ry]} :attrs} el
         rx (or rx ry)
         ry (or ry rx)
-        [cx cy rx ry] (mapv utils.length/unit->px [cx cy rx ry])]
-    (string/join " " ["M" (+ cx rx) cy
-                      "A" rx ry 0 0 1 cx (+ cy ry)
-                      "A" rx ry 0 0 1 (- cx rx) cy
-                      "A" rx ry 0 0 1 (+ cx rx) cy
-                      "z"])))
+        [cx cy rx ry] (mapv utils.length/unit->px [cx cy rx ry])
+        [krx kry] (matrix/mul [rx ry] utils.math/KAPPA)]
+    (->> ["M" (+ cx rx) cy
+          "C" (+ cx rx) (+ cy kry) (+ cx krx) (+ cy ry) cx (+ cy ry)
+          "S" (- cx rx) (+ cy kry) (- cx rx) cy
+          "S" (- cx krx) (- cy ry) cx (- cy ry)
+          "S" (+ cx rx) (- cy kry) (+ cx rx) cy
+          "z"]
+         (map #(cond-> % (number? %) utils.length/->fixed))
+         (string/join " "))))
 
 (defmethod element.hierarchy/area :ellipse
   [el]

--- a/src/renderer/element/impl/shape/line.cljs
+++ b/src/renderer/element/impl/shape/line.cljs
@@ -52,8 +52,10 @@
   [el]
   (let [{{:keys [x1 y1 x2 y2]} :attrs} el
         [x1 y1 x2 y2] (mapv utils.length/unit->px [x1 y1 x2 y2])]
-    (string/join " " ["M" x1 y1
-                      "L" x2 y2])))
+    (->> ["M" x1 y1
+          "L" x2 y2]
+         (map #(cond-> % (number? %) utils.length/->fixed))
+         (string/join " "))))
 
 (defmethod element.hierarchy/handles :line
   [el]

--- a/src/renderer/element/impl/shape/path.cljs
+++ b/src/renderer/element/impl/shape/path.cljs
@@ -156,22 +156,25 @@
       nil)))
 
 (defn segment-handles
-  [{:keys [parent endpoints segments offset]} index segment]
+  [{:keys [parent endpoints segments offset cp-indices]} index segment]
   (->> (handles endpoints segments index segment)
-       (mapv (fn [{:keys [point-type pos rounded implied cursor]}]
-               (let [label (-> (utils.path/segment->command segment)
-                               (attribute.impl.d/path-commands)
-                               :label)]
-                 (cond-> {:id (keyword index point-type)
-                          :position (matrix/add offset pos)
-                          :label label
-                          :type :handle
-                          :action :edit
-                          :implied (boolean implied)
-                          :rounded (boolean rounded)
-                          :parent parent}
-                   cursor
-                   (assoc :cursor cursor)))))))
+       (keep (fn [{:keys [point-type pos rounded implied cursor]}]
+               (when (or (= point-type :end-point)
+                         (contains? cp-indices index))
+                 (let [label (-> (utils.path/segment->command segment)
+                                 (attribute.impl.d/path-commands)
+                                 :label)]
+                   (cond-> {:id (keyword index point-type)
+                            :position (matrix/add offset pos)
+                            :label label
+                            :type :handle
+                            :action :edit
+                            :implied (boolean implied)
+                            :rounded (boolean rounded)
+                            :parent parent}
+                     cursor
+                     (assoc :cursor cursor))))))
+       (into [])))
 
 (m/=> acc-endpoints [:-> PathSegments [:vector Vec2]])
 (defn acc-endpoints
@@ -227,10 +230,15 @@
   (let [segments (->> el :attrs :d utils.path/string->segments)
         endpoints (acc-endpoints segments)
         offset (utils.element/offset el)
+        selected (->> (:selected-handles el)
+                      (keep #(some-> (namespace %) js/parseInt))
+                      (into #{}))
+        cp-indices (into #{} (mapcat (fn [i] [i (inc i)]) selected))
         props {:parent (:id el)
                :endpoints endpoints
                :segments segments
-               :offset offset}]
+               :offset offset
+               :cp-indices cp-indices}]
     (->> segments
          (map-indexed (partial segment-handles props))
          (flatten)
@@ -241,12 +249,18 @@
   (let [segments (->> el :attrs :d utils.path/string->segments)
         endpoints (acc-endpoints segments)
         offset (utils.element/offset el)
+        selected (->> (:selected-handles el)
+                      (keep #(some-> (namespace %) js/parseInt))
+                      (into #{}))
+        cp-indices (into #{} (mapcat (fn [i] [i (inc i)]) selected))
         props {:parent (:id el)
                :endpoints endpoints
                :segments segments
                :offset offset}]
     (->> segments
-         (map-indexed (partial render-arms props))
+         (map-indexed (fn [index segment]
+                        (when (contains? cp-indices index)
+                          (render-arms props index segment))))
          (into [:g]))))
 
 (m/=> translate-seg-point [:->

--- a/src/renderer/element/impl/shape/rect.cljs
+++ b/src/renderer/element/impl/shape/rect.cljs
@@ -2,6 +2,7 @@
   "https://www.w3.org/TR/SVG/shapes.html#RectElement
    https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/rect"
   (:require
+   [clojure.core.matrix :as matrix]
    [clojure.string :as string]
    [renderer.attribute.hierarchy :as attribute.hierarchy]
    [renderer.element.hierarchy :as element.hierarchy]
@@ -9,7 +10,8 @@
    [renderer.input.handlers :as input.handlers]
    [renderer.utils.bounds :as utils.bounds]
    [renderer.utils.element :as utils.element]
-   [renderer.utils.length :as utils.length]))
+   [renderer.utils.length :as utils.length]
+   [renderer.utils.math :as utils.math]))
 
 (hierarchy/derive! :rect ::element.hierarchy/box)
 (hierarchy/derive! :rect ::element.hierarchy/shape)
@@ -141,16 +143,22 @@
         ry (utils.length/unit->px (if (and (not ry) rx) rx ry))
         rx (if (> rx (/ width 2)) (/ width 2) rx)
         ry (if (> ry (/ height 2)) (/ height 2) ry)
-        curved? (and (> rx 0) (> ry 0))]
+        curved? (and (> rx 0) (> ry 0))
+        y2-full (+ y height)
+        x2-full (+ x width)
+        [x1 y1] (matrix/add [x y] [rx ry])
+        [x2 y2] (matrix/sub [x2-full y2-full] [rx ry])
+        [krx kry] (matrix/mul [rx ry] utils.math/KAPPA)]
     (cond-> []
-      :always (conj "M" (+ x rx) y
-                    "H" (- (+ x width) rx))
-      curved? (conj "A" rx ry 0 0 1 (+ x width) (+ y ry))
-      :always (conj "V" (- (+ y height) ry))
-      curved? (conj "A" rx ry 0 0 1 (- (+ x width) rx) (+ y height))
-      :always (conj "H" (+ x rx))
-      curved? (conj "A" rx ry 0 0 1 x (- (+ y height) ry))
-      curved? (conj "V" (+ y ry))
-      curved? (conj "A" rx ry 0 0 1 (+ x rx) y)
+      :always (conj "M" x1 y
+                    "L" x2 y)
+      curved? (conj "C" (+ x2 krx) y x2-full (- y1 kry) x2-full y1)
+      :always (conj "L" x2-full y2)
+      curved? (conj "C" x2-full (+ y2 kry) (+ x2 krx) y2-full x2 y2-full)
+      :always (conj "L" x1 y2-full)
+      curved? (conj "C" (- x1 krx) y2-full x (+ y2 kry) x y2)
+      curved? (conj "L" x y1)
+      curved? (conj "C" x (- y1 kry) (- x1 krx) y x1 y)
       :always (conj "z")
-      :always (->> (string/join " ")))))
+      :always (->> (map #(cond-> % (number? %) utils.length/->fixed))
+                   (string/join " ")))))

--- a/src/renderer/utils/math.cljs
+++ b/src/renderer/utils/math.cljs
@@ -4,6 +4,11 @@
    [malli.core :as m]
    [renderer.db :refer [Vec2]]))
 
+(def KAPPA
+  "Constant for converting a quarter-circle/ellipse arc to a cubic Bézier curve.
+   Calculated as: 4/3 * (√2 - 1)"
+  0.5522847498)
+
 (m/=> clamp [:-> number? number? number? number?])
 (defn clamp
   "Clamps a number within the provided bounds."

--- a/test/element_impl_test.cljs
+++ b/test/element_impl_test.cljs
@@ -32,9 +32,10 @@
 
     (is (= (element.hierarchy/path circle-el)
            (string/join " " ["M 50 0"
-                             "A 50 50 0 0 1 0 50"
-                             "A 50 50 0 0 1 -50 0"
-                             "A 50 50 0 0 1 50 0"
+                             "C 50 27.614 27.614 50 0 50"
+                             "S -50 27.614 -50 0"
+                             "S -27.614 -50 0 -50"
+                             "S 50 -27.614 50 0"
                              "z"])))))
 
 (deftest rect
@@ -68,8 +69,9 @@
 
     (is (= (element.hierarchy/path rect-el)
            (string/join " " ["M 0 0"
-                             "H 50 V 50"
-                             "H 0"
+                             "L 50 0"
+                             "L 50 50"
+                             "L 0 50"
                              "z"])))))
 
 (deftest ellipse
@@ -103,9 +105,10 @@
 
     (is (= (element.hierarchy/path ellipse-el)
            (string/join " " ["M 50 0"
-                             "A 50 50 0 0 1 0 50"
-                             "A 50 50 0 0 1 -50 0"
-                             "A 50 50 0 0 1 50 0"
+                             "C 50 27.614 27.614 50 0 50"
+                             "S -50 27.614 -50 0"
+                             "S -27.614 -50 0 -50"
+                             "S 50 -27.614 50 0"
                              "z"])))))
 
 (deftest line


### PR DESCRIPTION
<img width="2031" height="798" alt="Screenshot From 2026-06-05 18-04-01" src="https://github.com/user-attachments/assets/49180ca9-c082-4369-9d24-09cc74c79e7a" />

This PR modifies the path output of rect/circle/ellipse in order to produce easier to modify paths, by replacing arcs (`A`) with bezier curves (`S` or `C`)  and horizontal/vertical lines (`H` and `V`) with lines (`L`).  We now also hide additional path controls for non selected segments, to help with convoluted edit scenes, and also improve performance. 