### PR TITLE
Introduce combine and break apart path operations

### DIFF
--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "إلغاء تجميع التحديد"
   :cut-selection "قص التحديد"
   :trace-image "تتبع الصورة"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "دمج"
+  :break-apart "فصل"}
 
  :renderer.element.impl.animation.animate
  {:label "تحريك"
@@ -753,6 +755,8 @@
   :boolean-intersect "تقاطع"
   :boolean-subtract "طرح"
   :boolean-divide "قسمة"
+  :combine "دمج"
+  :break-apart "فصل"
   :raise "رفع"
   :lower "خفض"
   :raise-to-top "رفع إلى الأعلى"

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "Auswahl gruppierung aufheben"
   :cut-selection "Auswahl ausschneiden"
   :trace-image "Bild nachzeichnen"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Kombinieren"
+  :break-apart "Trennen"}
 
  :renderer.element.impl.animation.animate
  {:label "Animieren"
@@ -801,6 +803,8 @@
   :boolean-intersect "Schnittmenge"
   :boolean-subtract "Subtrahieren"
   :boolean-divide "Teilen"
+  :combine "Kombinieren"
+  :break-apart "Trennen"
   :raise "Nach vorne"
   :lower "Nach hinten"
   :raise-to-top "Ganz nach vorne"

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "Αποομαδοποίηση επιλογής"
   :cut-selection "Αποκοπή επιλογής"
   :trace-image "Ανίχνευση εικόνας"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Συνδυασμός"
+  :break-apart "Διάσπαση"}
 
  :renderer.element.impl.animation.animate
  {:label "Κίνηση"
@@ -803,6 +805,8 @@
   :boolean-intersect "Τομή"
   :boolean-subtract "Αφαίρεση"
   :boolean-divide "Διαίρεση"
+  :combine "Συνδυασμός"
+  :break-apart "Διάσπαση"
   :raise "Ανέβασμα"
   :lower "Κατέβασμα"
   :raise-to-top "Μετακίνηση προς τα πάνω"

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "Ungroup selection"
   :cut-selection "Cut selection"
   :trace-image "Trace image"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Combine"
+  :break-apart "Break apart"}
 
  :renderer.element.impl.animation.animate
  {:label "Animate"
@@ -766,6 +768,8 @@
   :boolean-intersect "Intersect"
   :boolean-subtract "Subtract"
   :boolean-divide "Divide"
+  :combine "Combine"
+  :break-apart "Break apart"
   :raise "Raise"
   :lower "Lower"
   :raise-to-top "Raise to top"

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "Desagrupar selección"
   :cut-selection "Cortar selección"
   :trace-image "Vectorizar imagen"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Combinar"
+  :break-apart "Separar"}
 
  :renderer.element.impl.animation.animate
  {:label "Animar"
@@ -785,6 +787,8 @@
   :boolean-intersect "Intersectar"
   :boolean-subtract "Sustraer"
   :boolean-divide "Dividir"
+  :combine "Combinar"
+  :break-apart "Separar"
   :raise "Subir"
   :lower "Bajar"
   :raise-to-top "Subir al frente"

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -111,7 +111,9 @@
   :ungroup-selection "Dégrouper la sélection"
   :cut-selection "Couper la sélection"
   :trace-image "Vectoriser l'image"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Combiner"
+  :break-apart "Séparer"}
 
  :renderer.element.impl.animation.animate
  {:label "Animer"
@@ -792,6 +794,8 @@
   :boolean-intersect "Intersecter"
   :boolean-subtract "Soustraire"
   :boolean-divide "Diviser"
+  :combine "Combiner"
+  :break-apart "Séparer"
   :raise "Monter"
   :lower "Descendre"
   :raise-to-top "Monter au premier plan"

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -111,7 +111,9 @@
   :ungroup-selection "Separa selezione"
   :cut-selection "Taglia selezione"
   :trace-image "Traccia immagine"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Combina"
+  :break-apart "Separa"}
 
  :renderer.element.impl.animation.animate
  {:label "Anima"
@@ -795,6 +797,8 @@
   :boolean-intersect "Interseca"
   :boolean-subtract "Sottrai"
   :boolean-divide "Dividi"
+  :combine "Combina"
+  :break-apart "Separa"
   :raise "Porta avanti"
   :lower "Porta dietro"
   :raise-to-top "Porta in primo piano"

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "選択のグループ化を解除"
   :cut-selection "選択を切り取り"
   :trace-image "画像をトレース"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "複合"
+  :break-apart "分割"}
 
  :renderer.element.impl.animation.animate
  {:label "アニメーション"
@@ -737,6 +739,8 @@
   :boolean-intersect "交差"
   :boolean-subtract "減算"
   :boolean-divide "分割"
+  :combine "複合"
+  :break-apart "分割"
   :raise "前面へ"
   :lower "背面へ"
   :raise-to-top "最前面へ"

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "선택 그룹 해제"
   :cut-selection "선택 잘라내기"
   :trace-image "이미지 추적"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "결합"
+  :break-apart "분리"}
 
  :renderer.element.impl.animation.animate
  {:label "애니메이션"
@@ -732,6 +734,8 @@
   :boolean-intersect "교집합"
   :boolean-subtract "빼기"
   :boolean-divide "나누기"
+  :combine "결합"
+  :break-apart "분리"
   :raise "앞으로"
   :lower "뒤로"
   :raise-to-top "맨 앞으로"

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "Selectiegroepering opheffen"
   :cut-selection "Selectie knippen"
   :trace-image "Afbeelding traceren"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Combineren"
+  :break-apart "Opsplitsen"}
 
  :renderer.element.impl.animation.animate
  {:label "Animeren"
@@ -796,6 +798,8 @@
   :boolean-intersect "Doorsnede"
   :boolean-subtract "Aftrekken"
   :boolean-divide "Verdelen"
+  :combine "Combineren"
+  :break-apart "Opsplitsen"
   :raise "Naar voren"
   :lower "Naar achteren"
   :raise-to-top "Naar voorgrond"

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "Desagrupar seleção"
   :cut-selection "Cortar seleção"
   :trace-image "Vetorizar imagem"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Combinar"
+  :break-apart "Separar"}
 
  :renderer.element.impl.animation.animate
  {:label "Animar"
@@ -778,6 +780,8 @@
   :boolean-intersect "Intersetar"
   :boolean-subtract "Subtrair"
   :boolean-divide "Dividir"
+  :combine "Combinar"
+  :break-apart "Separar"
   :raise "Subir"
   :lower "Descer"
   :raise-to-top "Subir para frente"

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -111,7 +111,9 @@
   :ungroup-selection "Разгруппировать выделенное"
   :cut-selection "Вырезать выделенное"
   :trace-image "Трассировать изображение"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Совместить"
+  :break-apart "Разбить"}
 
  :renderer.element.impl.animation.animate
  {:label "Анимировать"
@@ -779,6 +781,8 @@
   :boolean-intersect "Пересечение"
   :boolean-subtract "Вычесть"
   :boolean-divide "Разделить"
+  :combine "Совместить"
+  :break-apart "Разбить"
   :raise "Поднять"
   :lower "Опустить"
   :raise-to-top "Поднять на передний план"

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "Dela upp markeringsgrupp"
   :cut-selection "Klipp ut markering"
   :trace-image "Spåra bild"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Kombinera"
+  :break-apart "Dela upp"}
 
  :renderer.element.impl.animation.animate
  {:label "Animera"
@@ -780,6 +782,8 @@
   :boolean-intersect "Skära"
   :boolean-subtract "Subtrahera"
   :boolean-divide "Dela"
+  :combine "Kombinera"
+  :break-apart "Dela upp"
   :raise "Lyft fram"
   :lower "Lägg bak"
   :raise-to-top "Lyft till toppen"

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -110,7 +110,9 @@
   :ungroup-selection "Seçim grubunu çöz"
   :cut-selection "Seçimi kes"
   :trace-image "Resim izini sür"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "Kombine"
+  :break-apart "Parçalara Ayır"}
 
  :renderer.element.impl.animation.animate
  {:label "Animasyon"
@@ -774,6 +776,8 @@
   :boolean-intersect "Kesişim"
   :boolean-subtract "Çıkar"
   :boolean-divide "Böl"
+  :combine "Kombine"
+  :break-apart "Parçalara Ayır"
   :raise "Öne getir"
   :lower "Arkaya gönder"
   :raise-to-top "En öne getir"

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -109,7 +109,9 @@
   :ungroup-selection "选择取消成组"
   :cut-selection "剪切选择"
   :trace-image "描摹图像"
-  :toggle-handle-selection "Toggle handle selection"}
+  :toggle-handle-selection "Toggle handle selection"
+  :combine "组合"
+  :break-apart "拆分"}
 
  :renderer.element.impl.animation.animate
  {:label "动画"
@@ -698,6 +700,8 @@
   :boolean-intersect "相交"
   :boolean-subtract "差集"
   :boolean-divide "分割"
+  :combine "组合"
+  :break-apart "拆分"
   :raise "上移"
   :lower "下移"
   :raise-to-top "置于顶层"

--- a/src/renderer/attribute/views.cljs
+++ b/src/renderer/attribute/views.cljs
@@ -306,11 +306,11 @@
   (let [selected-elements @(rf/subscribe [::element.subs/selected])
         selected-tags @(rf/subscribe [::element.subs/selected-tags])
         edit-attributes @(rf/subscribe [::element.subs/edit-attributes])
-        selected-locked? @(rf/subscribe [::element.subs/selected-locked?])
+        locked? @(rf/subscribe [::element.subs/every-selected-locked?])
         tool-state @(rf/subscribe [::tool.subs/state])
         tool-cached-state @(rf/subscribe [::tool.subs/cached-state])
         tag (first selected-tags)
-        locked? (or selected-locked?
+        locked? (or locked?
                     (not= tool-state :idle)
                     (and tool-cached-state (not= tool-cached-state :idle)))]
     (when-first [el selected-elements]

--- a/src/renderer/element/core.cljs
+++ b/src/renderer/element/core.cljs
@@ -310,35 +310,54 @@
                :label [::path-simplify "Simplify"]
                :icon "bezier-curve"
                :event [::element.events/manipulate-path :simplify]
-               :enabled [::element.subs/has-selected-tag? :path]}])
+               :enabled [::element.subs/some-selected-tag? :path]}])
 
 (rf/dispatch [::action.events/register-action
               {:id :path/smooth
                :label [::path-smooth "Smooth"]
                :icon "bezier-curve"
                :event [::element.events/manipulate-path :smooth]
-               :enabled [::element.subs/has-selected-tag? :path]}])
+               :enabled [::element.subs/some-selected-tag? :path]}])
 
 (rf/dispatch [::action.events/register-action
               {:id :path/flatten
                :label [::path-flatten "Flatten"]
                :icon "bezier-curve"
                :event [::element.events/manipulate-path :flatten]
-               :enabled [::element.subs/has-selected-tag? :path]}])
+               :enabled [::element.subs/some-selected-tag? :path]}])
 
 (rf/dispatch [::action.events/register-action
               {:id :path/reverse
                :label [::path-reverse "Reverse"]
                :icon "bezier-curve"
                :event [::element.events/manipulate-path :reverse]
-               :enabled [::element.subs/has-selected-tag? :path]}])
+               :enabled [::element.subs/some-selected-tag? :path]}])
+
+(rf/dispatch [::action.events/register-action
+              {:id :path/combine
+               :label [::combine "Combine"]
+               :icon "group"
+               :event [::element.events/combine]
+               :enabled [::element.subs/some-selected-tag? :path]
+               :shortcuts [{:keyCode (utils.key/codes "M")
+                            :ctrlKey true}]}])
+
+(rf/dispatch [::action.events/register-action
+              {:id :path/break-apart
+               :label [::break-apart "Break apart"]
+               :icon "ungroup"
+               :event [::element.events/break-apart]
+               :enabled [::element.subs/some-selected-tag? :path]
+               :shortcuts [{:keyCode (utils.key/codes "M")
+                            :ctrlKey true
+                            :shiftKey true}]}])
 
 (rf/dispatch [::action.events/register-action
               {:id :image/trace
                :label [::image-trace "Trace"]
                :icon "image"
                :event [::element.events/trace]
-               :enabled [::element.subs/has-selected-tag? :image]}])
+               :enabled [::element.subs/some-selected-tag? :image]}])
 
 (rf/dispatch [::action.events/register-action-group
               {:id :object/index-operations
@@ -410,16 +429,18 @@
 (rf/dispatch [::action.events/register-action-group
               {:id :object/path-operations
                :label [::path "Path"]
-               :enabled [::element.subs/has-selected-tag? :path]
+               :enabled [::element.subs/some-selected-tag? :path]
                :actions [:path/simplify
                          :path/smooth
                          :path/flatten
-                         :path/reverse]}])
+                         :path/reverse
+                         :path/combine
+                         :path/break-apart]}])
 
 (rf/dispatch [::action.events/register-action-group
               {:id :object/image-operations
                :label [::image "Image"]
-               :enabled [::element.subs/has-selected-tag? :image]
+               :enabled [::element.subs/some-selected-tag? :image]
                :actions [:image/trace]}])
 
 (rf/dispatch [::action.events/register-action-group

--- a/src/renderer/element/events.cljs
+++ b/src/renderer/element/events.cljs
@@ -243,6 +243,18 @@
        (element.handlers/boolean-operation operation))))
 
 (rf/reg-event-db
+ ::combine
+ [(finalize [::combine "Combine"])]
+ (fn [db _]
+   (element.handlers/combine db)))
+
+(rf/reg-event-db
+ ::break-apart
+ [(finalize [::break-apart "Break apart"])]
+ (fn [db _]
+   (element.handlers/break-apart db)))
+
+(rf/reg-event-db
  ::add
  [(finalize (fn [[_ el]] [[::create "Create %1"] [(name (:tag el))]]))]
  (fn [db [_ el]]

--- a/src/renderer/element/handlers.cljs
+++ b/src/renderer/element/handlers.cljs
@@ -888,6 +888,43 @@
                 :parent (-> selected-elements first :parent)
                 :attrs (merge attrs {:d new-path})})))))
 
+(m/=> combine [:-> App App])
+(defn combine
+  [db]
+  (let [selected-path-elements (->> (filter-selected-by-tag db :path)
+                                    (sort-by-index-path db))]
+    (if (> (count selected-path-elements) 1)
+      (-> (reduce (fn [db el] (delete db (:id el))) db selected-path-elements)
+          (add {:type :element
+                :tag :path
+                :parent (:parent (first selected-path-elements))
+                :attrs (merge (:attrs (first selected-path-elements))
+                              {:d (->> selected-path-elements
+                                       (map #(get-in % [:attrs :d]))
+                                       (string/join " "))})}))
+      db)))
+
+(m/=> break-apart [:-> App App])
+(defn break-apart
+  [db]
+  (let [selected-path-elements (->> (filter-selected-by-tag db :path)
+                                    (sort-by-index-path db))
+        db (-> (reduce (fn [db el]
+                         (delete db (:id el))) db selected-path-elements)
+               (deselect))]
+    (reduce (fn [db el]
+              (let [segments (utils.path/string->segments (-> el :attrs :d))
+                    broken-segments (utils.path/break-apart segments)]
+                (reduce (fn [db seg]
+                          (let [d (utils.path/segments->string seg)]
+                            (create db {:type :element
+                                        :tag :path
+                                        :selected true
+                                        :parent (:parent el)
+                                        :attrs (assoc (:attrs el) :d d)})))
+                        db broken-segments)))
+            db selected-path-elements)))
+
 (m/=> paste-in-place [:function
                       [:-> App App]
                       [:-> App Element App]])

--- a/src/renderer/element/subs.cljs
+++ b/src/renderer/element/subs.cljs
@@ -69,7 +69,7 @@
  :-> (comp set (partial map :tag)))
 
 (rf/reg-sub
- ::has-selected-tag?
+ ::some-selected-tag?
  :<- [::selected-tags]
  :=> contains?)
 
@@ -79,7 +79,7 @@
  :-> (comp boolean seq))
 
 (rf/reg-sub
- ::selected-locked?
+ ::every-selected-locked?
  :<- [::selected]
  :-> (partial every? :locked))
 

--- a/src/renderer/utils/path.cljs
+++ b/src/renderer/utils/path.cljs
@@ -206,6 +206,16 @@
           (doto (.slice segments) (aset index new-seg))
           segments)))))
 
+(m/=> break-apart [:-> PathSegments [:vector PathSegments]])
+(defn break-apart
+  [segments]
+  (reduce (fn [acc segment]
+            (if (= "M" (segment->command segment))
+              (conj acc [segment])
+              (update acc (dec (count acc)) conj segment)))
+          []
+          segments))
+
 (m/=> boolean-operation [:-> string? string? BooleanOperation string?])
 (defn boolean-operation
   [path-a path-b operation]


### PR DESCRIPTION
We can now combine or break apart paths by using the introduced actions and their corresponding shortcuts (`Ctrl+M` `Ctrl+Shift+M`). Those actions are only applied to the currently selected path objects, without converting other element types to paths.

https://github.com/user-attachments/assets/4b6c6142-54fc-4c88-a2e5-7d53fb02bbde

