### PR TITLE
Introduce active tool options

### DIFF
--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -352,7 +352,8 @@
   :release-to-finalize "أفلت لإنهاء العنصر."
   :edge "حافة"
   :elements "عناصر"
-  :containers "حاويات"}
+  :containers "حاويات"
+  :select-stroke-width "تحديد عرض الحد"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "انقر لبدء الرسم."
@@ -538,7 +539,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "تحويل"
-  :pivot-point "نقطة الارتكاز"}
+  :pivot-point "نقطة الارتكاز"
+  :lock-aspect-ratio "قفل نسبة الأبعاد"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "اضغط %1 لتقييد الاتجاه. أو حرر %2 للتحريك"]

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -381,7 +381,8 @@
   :release-to-finalize "Loslassen, um das Element abzuschließen."
   :edge "Kante"
   :elements "Elemente"
-  :containers "Container"}
+  :containers "Container"
+  :select-stroke-width "Strichbreite auswählen"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Klicken, um mit dem Zeichnen zu beginnen."
@@ -579,7 +580,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Transformieren"
-  :pivot-point "Drehpunkt"}
+  :pivot-point "Drehpunkt"
+  :lock-aspect-ratio "Seitenverhältnis sperren"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Halten Sie %1, um die Richtung zu beschränken. oder lassen Sie

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -385,7 +385,8 @@
   :release-to-finalize "Αφήστε για να οριστικοποιήσετε το στοιχείο."
   :edge "άκρη"
   :elements "Στοιχεία"
-  :containers "Κοντέινερ"}
+  :containers "Κοντέινερ"
+  :select-stroke-width "Επιλογή πλάτους γραμμής"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Κάντε κλικ για να ξεκινήσετε τη σχεδίαση."
@@ -583,7 +584,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Μετασχηματισμός"
-  :pivot-point "σημείο περιστροφής"}
+  :pivot-point "σημείο περιστροφής"
+  :lock-aspect-ratio "Κλείδωμα αναλογίας"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Πιέστε %1 για περιορισμό κατεύθυνσης. ή αφήστε %2 για

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -381,7 +381,8 @@
   :release-to-finalize "Release to finalize the element."
   :edge "edge"
   :elements "Elements"
-  :containers "Containers"}
+  :containers "Containers"
+  :select-stroke-width "Select stroke width"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Click to start drawing."
@@ -551,7 +552,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Transform"
-  :pivot-point "pivot point"}
+  :pivot-point "pivot point"
+  :lock-aspect-ratio "Lock aspect ratio"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Hold %1 to restrict direction. or release %2 to move"]

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -370,7 +370,8 @@
   :release-to-finalize "Suelte para finalizar el elemento."
   :edge "borde"
   :elements "Elementos"
-  :containers "Contenedores"}
+  :containers "Contenedores"
+  :select-stroke-width "Seleccionar ancho de trazo"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Haga clic para empezar a dibujar."
@@ -563,7 +564,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Transformar"
-  :pivot-point "punto de pivote"}
+  :pivot-point "punto de pivote"
+  :lock-aspect-ratio "Bloquear relación de aspecto"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Mantenga %1 para restringir la dirección. o suelte %2 para

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -375,7 +375,8 @@
   :release-to-finalize "Relâchez pour finaliser l'élément."
   :edge "bord"
   :elements "Éléments"
-  :containers "Conteneurs"}
+  :containers "Conteneurs"
+  :select-stroke-width "Sélectionner la largeur du trait"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Cliquez pour commencer à dessiner."
@@ -569,7 +570,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Transformer"
-  :pivot-point "point de pivot"}
+  :pivot-point "point de pivot"
+  :lock-aspect-ratio "Verrouiller les proportions"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Maintenez %1 pour restreindre la direction. ou relâchez %2 pour

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -398,7 +398,8 @@
   :release-to-finalize "Rilascia per finalizzare l'elemento."
   :edge "bordo"
   :elements "Elementi"
-  :containers "Contenitori"}
+  :containers "Contenitori"
+  :select-stroke-width "Seleziona larghezza tratto"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Clicca per iniziare a disegnare."
@@ -574,7 +575,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Trasforma"
-  :pivot-point "punto di pivot"}
+  :pivot-point "punto di pivot"
+  :lock-aspect-ratio "Blocca proporzioni"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Tieni premuto %1 per limitare la direzione. o rilascia %2 per

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -337,7 +337,8 @@
   :release-to-finalize "要素を確定するには離す。"
   :edge "エッジ"
   :elements "要素"
-  :containers "コンテナ"}
+  :containers "コンテナ"
+  :select-stroke-width "ストローク幅を選択"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "クリックして描画を開始。"
@@ -523,7 +524,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "変形"
-  :pivot-point "ピボットポイント"}
+  :pivot-point "ピボットポイント"
+  :lock-aspect-ratio "アスペクト比を固定"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "%1を押しながら方向を制限。または%2を離して移動"]

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -351,7 +351,8 @@
   :release-to-finalize "요소를 완료하려면 놓으세요."
   :edge "가장자리"
   :elements "요소"
-  :containers "컨테이너"}
+  :containers "컨테이너"
+  :select-stroke-width "획 너비 선택"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "클릭하여 그리기를 시작합니다."
@@ -519,7 +520,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "변환"
-  :pivot-point "피벗 포인트"}
+  :pivot-point "피벗 포인트"
+  :lock-aspect-ratio "가로세로 비율 잠금"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "%1을 누르면 방향을 제한하거나 %2를 놓으면 이동합니다"]

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -400,7 +400,8 @@
   :release-to-finalize "Loslaten om het element te voltooien."
   :edge "rand"
   :elements "Elementen"
-  :containers "Containers"}
+  :containers "Containers"
+  :select-stroke-width "Lijnbreedte selecteren"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Klik om te beginnen met tekenen."
@@ -576,7 +577,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Transformeren"
-  :pivot-point "draaipunt"}
+  :pivot-point "draaipunt"
+  :lock-aspect-ratio "Beeldverhouding vergrendelen"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Houd %1 ingedrukt om richting te beperken. of laat %2 los om

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -367,7 +367,8 @@
   :release-to-finalize "Solte para finalizar o elemento."
   :edge "borda"
   :elements "Elementos"
-  :containers "Contêineres"}
+  :containers "Contêineres"
+  :select-stroke-width "Selecionar largura do traço"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Clique para começar a desenhar."
@@ -560,7 +561,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Transformar"
-  :pivot-point "ponto de pivô"}
+  :pivot-point "ponto de pivô"
+  :lock-aspect-ratio "Bloquear proporção"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Mantenha %1 para restringir direção. ou solte %2 para mover"]

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -363,7 +363,8 @@
   :release-to-finalize "Отпустите для завершения элемента."
   :edge "край"
   :elements "Элементы"
-  :containers "Контейнеры"}
+  :containers "Контейнеры"
+  :select-stroke-width "Выбрать ширину обводки"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Щёлкните для начала рисования."
@@ -558,7 +559,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Трансформация"
-  :pivot-point "точка поворота"}
+  :pivot-point "точка поворота"
+  :lock-aspect-ratio "Заблокировать соотношение сторон"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Удерживайте %1 для ограничения направления. или отпустите %2

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -389,7 +389,8 @@
   :release-to-finalize "Släpp för att slutföra elementet."
   :edge "kant"
   :elements "Element"
-  :containers "Behållare"}
+  :containers "Behållare"
+  :select-stroke-width "Välj linjebredd"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Klicka för att börja rita."
@@ -562,7 +563,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Transformera"
-  :pivot-point "rotationspunkt"}
+  :pivot-point "rotationspunkt"
+  :lock-aspect-ratio "Lås bildförhållande"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Håll %1 för att begränsa riktning. eller släpp %2 för att

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -382,7 +382,8 @@
   :release-to-finalize "Öğeyi tamamlamak için bırakın."
   :edge "kenar"
   :elements "Öğeler"
-  :containers "Kapsayıcılar"}
+  :containers "Kapsayıcılar"
+  :select-stroke-width "Çizgi kalınlığı seçin"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "Çizmeye başlamak için tıklayın."
@@ -554,7 +555,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "Dönüştür"
-  :pivot-point "pivot noktası"}
+  :pivot-point "pivot noktası"
+  :lock-aspect-ratio "En-boy oranını kilitle"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "Yönü kısıtlamak için %1 tuşunu basılı tutun. veya taşımak için

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -307,7 +307,8 @@
   :release-to-finalize "松开以完成元素。"
   :edge "边缘"
   :elements "元素"
-  :containers "容器"}
+  :containers "容器"
+  :select-stroke-width "选择描边宽度"}
 
  :renderer.tool.impl.element.poly
  {:click-to-start "点击开始绘制。"
@@ -485,7 +486,8 @@
 
  :renderer.tool.impl.base.transform.core
  {:label "变换"
-  :pivot-point "旋转中心点"}
+  :pivot-point "旋转中心点"
+  :lock-aspect-ratio "锁定宽高比"}
 
  :renderer.tool.impl.base.transform.clone
  {:clone [:div "按住 %1 限制方向。或释放 %2 进行移动"]

--- a/src/renderer/attribute/impl/d.cljs
+++ b/src/renderer/attribute/impl/d.cljs
@@ -224,7 +224,7 @@
      [:> Select/Trigger
       {:class "form-control-button flex gap-1 px-2!
                bg-transparent! hover:bg-overlay! text-inherit!"
-       :title (i18n.views/t [::convert-segment "Convert segment"])}
+       :aria-label (i18n.views/t [::convert-segment "Convert segment"])}
       [:div.absolute [:> Select/Value ""]]
       [:span.text-ellipsis.overflow-hidden (i18n.views/t label)]
       (when-not disabled?

--- a/src/renderer/document/db.cljs
+++ b/src/renderer/document/db.cljs
@@ -18,6 +18,8 @@
 
 (def DocumentTitle [:string {:min 1}])
 
+(def DocumentAttrs [:map-of keyword? any?])
+
 (def Document
   [:map {:closed true}
    [:id {:optional true
@@ -39,7 +41,8 @@
                :persist true} [:map-of ElementId Element]]
    [:centered {:optional true} boolean?]
    [:attrs {:default {:fill "lightgray"
-                      :stroke "black"}} [:map-of keyword? string?]]
+                      :stroke "black"
+                      :stroke-width "1px"}} DocumentAttrs]
    [:preview-label {:optional true} string?]
    [:file-handle {:optional true} JS_Object]])
 

--- a/src/renderer/document/events.cljs
+++ b/src/renderer/document/events.cljs
@@ -75,6 +75,12 @@
    (document.handlers/assoc-attr db k v)))
 
 (rf/reg-event-db
+ ::toggle-attr
+ [persist]
+ (fn [db [_ k]]
+   (document.handlers/update-attr db k not)))
+
+(rf/reg-event-db
  ::preview-attr
  (fn [db [_ k v]]
    (-> db

--- a/src/renderer/document/handlers.cljs
+++ b/src/renderer/document/handlers.cljs
@@ -7,7 +7,8 @@
    [renderer.db :refer [Vec2]]
    [renderer.document.db
     :as document.db
-    :refer [Document DocumentId DocumentTitle PersistedDocument RecentDocument]]
+    :refer [Document DocumentAttrs DocumentId DocumentTitle PersistedDocument
+            RecentDocument]]
    [renderer.element.db :refer [ElementId]]
    [renderer.element.handlers :as element.handlers]
    [renderer.frame.handlers :as frame.handlers]
@@ -177,15 +178,25 @@
     (expand-el db id)
     (collapse-el db id)))
 
+(m/=> attrs [:-> App DocumentAttrs])
+(defn attrs
+  [db]
+  (-> db active :attrs))
+
 (m/=> attr [:-> App keyword? string?])
 (defn attr
   [db k]
-  (get-in (active db) [:attrs k]))
+  (get (attrs db) k))
 
 (m/=> assoc-attr [:-> App keyword? string? App])
 (defn assoc-attr
   [db k v]
   (assoc-in db (path db :attrs k) v))
+
+(m/=> update-attr [:-> App keyword? ifn? [:* any?] App])
+(defn update-attr
+  [db k f & args]
+  (apply update-in db (path db :attrs k) f args))
 
 (m/=> update-saved-history-index [:function
                                   [:-> App App]

--- a/src/renderer/document/subs.cljs
+++ b/src/renderer/document/subs.cljs
@@ -94,14 +94,9 @@
  :-> :attrs)
 
 (rf/reg-sub
- ::fill
+ ::attr
  :<- [::attrs]
- :-> :fill)
-
-(rf/reg-sub
- ::stroke
- :<- [::attrs]
- :-> :stroke)
+ :=> get)
 
 (rf/reg-sub
  ::pan

--- a/src/renderer/tool/hierarchy.cljs
+++ b/src/renderer/tool/hierarchy.cljs
@@ -18,6 +18,7 @@
 (defmulti snapping-elements dispatch :hierarchy hierarchy/hierarchy)
 (defmulti on-delete dispatch :hierarchy hierarchy/hierarchy)
 (defmulti help (fn [tool state] [tool state]) :hierarchy hierarchy/hierarchy)
+(defmulti tool-options identity :hierarchy hierarchy/hierarchy)
 (defmulti render identity :hierarchy hierarchy/hierarchy)
 (defmulti attributes-panel identity :hierarchy hierarchy/hierarchy)
 (defmulti on-deactivate :tool :hierarchy hierarchy/hierarchy)

--- a/src/renderer/tool/impl/base/transform/core.cljs
+++ b/src/renderer/tool/impl/base/transform/core.cljs
@@ -4,12 +4,14 @@
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
    [renderer.app.subs :as-alias app.subs]
+   [renderer.document.events :as-alias document.events]
    [renderer.document.subs :as-alias document.subs]
    [renderer.element.db :refer [Element]]
    [renderer.element.handlers :as element.handlers]
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.element.subs :as-alias element.subs]
    [renderer.hierarchy :as hierarchy]
+   [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -22,9 +24,17 @@
    [renderer.tool.views :as tool.views]
    [renderer.utils.bounds :as utils.bounds]
    [renderer.utils.length :as utils.length]
-   [renderer.utils.svg :as utils.svg]))
+   [renderer.utils.svg :as utils.svg]
+   [renderer.views :as views]))
 
 (hierarchy/derive! ::transform ::tool.hierarchy/tool)
+
+(defmethod tool.hierarchy/tool-options ::transform
+  []
+  (let [ratio-locked? @(rf/subscribe [::document.subs/attr :lock-ratio])]
+    [views/radio-icon-button "lock" ratio-locked?
+     {:title (i18n.views/t [::lock-ratio "Lock aspect ratio"])
+      :on-click #(rf/dispatch [::document.events/toggle-attr :lock-ratio])}]))
 
 (defmethod tool.hierarchy/on-deactivate ::transform
   [db]

--- a/src/renderer/tool/impl/base/transform/core.cljs
+++ b/src/renderer/tool/impl/base/transform/core.cljs
@@ -33,7 +33,7 @@
   []
   (let [ratio-locked? @(rf/subscribe [::document.subs/attr :lock-ratio])]
     [views/radio-icon-button "lock" ratio-locked?
-     {:title (i18n.views/t [::lock-ratio "Lock aspect ratio"])
+     {:title (i18n.views/t [::lock-aspect-ratio "Lock aspect ratio"])
       :on-click #(rf/dispatch [::document.events/toggle-attr :lock-ratio])}]))
 
 (defmethod tool.hierarchy/on-deactivate ::transform

--- a/src/renderer/tool/impl/base/transform/scale.cljs
+++ b/src/renderer/tool/impl/base/transform/scale.cljs
@@ -4,6 +4,7 @@
    [malli.core :as m]
    [renderer.app.db :refer [App]]
    [renderer.db :refer [BBox Vec2]]
+   [renderer.document.handlers :as document.handlers]
    [renderer.element.handlers :as element.handlers]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
@@ -131,7 +132,8 @@
   [db e]
   (or (:ctrl-key e)
       (input.handlers/multi-touch? db)
-      (element.handlers/ratio-locked? db)))
+      (element.handlers/ratio-locked? db)
+      (document.handlers/attr db :lock-ratio)))
 
 (defmethod tool.hierarchy/on-drag [::transform/transform :scale]
   [db e]

--- a/src/renderer/tool/impl/element/circle.cljs
+++ b/src/renderer/tool/impl/element/circle.cljs
@@ -23,17 +23,15 @@
         position (tool.handlers/snapped-position db)
         radius (matrix/distance position offset)
         [cx cy] offset
-        fill (document.handlers/attr db :fill)
-        stroke (document.handlers/attr db :stroke)]
+        attrs (-> (document.handlers/attrs db)
+                  (select-keys [:stroke :fill :stroke-width]))]
     (-> db
         (tool.handlers/set-state :create)
         (element.handlers/add {:type :element
                                :tag :circle
-                               :attrs {:cx cx
-                                       :cy cy
-                                       :fill fill
-                                       :stroke stroke
-                                       :r radius}}))))
+                               :attrs (merge attrs {:cx cx
+                                                    :cy cy
+                                                    :r radius})}))))
 
 (defn update-el
   [db]

--- a/src/renderer/tool/impl/element/core.cljs
+++ b/src/renderer/tool/impl/element/core.cljs
@@ -1,7 +1,10 @@
 (ns renderer.tool.impl.element.core
   (:require
+   ["@radix-ui/react-select" :as Select]
    [re-frame.core :as rf]
    [renderer.action.events :as-alias action.events]
+   [renderer.document.events :as-alias document.events]
+   [renderer.document.subs :as-alias document.subs]
    [renderer.element.handlers :as element.handlers]
    [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
@@ -17,9 +20,47 @@
    [renderer.tool.impl.element.polyline]
    [renderer.tool.impl.element.rect]
    [renderer.tool.impl.element.svg]
-   [renderer.tool.impl.element.text]))
+   [renderer.tool.impl.element.text]
+   [renderer.views :as views]))
 
 (hierarchy/derive! ::tool.hierarchy/element ::tool.hierarchy/tool)
+
+(defn line
+  [stroke-width]
+  [:div.bg-foreground-muted.flex-1
+   {:style {:height stroke-width}}])
+
+(defn select-item
+  [value]
+  [:> Select/Item
+   {:value value
+    :class "menu-item px-2!"}
+   [:div.flex.items-center.gap-2.w-26
+    [:> Select/ItemText value]
+    [line value]]])
+
+(defmethod tool.hierarchy/tool-options ::tool.hierarchy/element
+  []
+  (let [stroke-width @(rf/subscribe [::document.subs/attr :stroke-width])]
+    [:> Select/Root
+     {:value stroke-width
+      :onValueChange #(rf/dispatch [::document.events/set-attr
+                                    :stroke-width %])}
+     [:> Select/Trigger
+      {:class "form-control-button rounded-sm px-2!"
+       :aria-label (i18n.views/t [::select-stroke-width "Select stroke width"])}
+      [:div.flex.items-center.gap-2.w-26
+       [:> Select/Value stroke-width]
+       [line stroke-width]
+       [:> Select/Icon
+        [views/icon "chevron-down"]]]]
+     [:> Select/Portal
+      [:> Select/Content
+       {:class "menu-content rounded-sm select-content"
+        :on-key-down #(.stopPropagation %)
+        :on-escape-key-down #(.stopPropagation %)}
+       (->> (map select-item ["1px" "2px" "4px" "8px"])
+            (into [:> Select/Viewport {:class "select-viewport"}]))]]]))
 
 (defmethod tool.hierarchy/help [::tool.hierarchy/element :idle]
   []

--- a/src/renderer/tool/impl/element/ellipse.cljs
+++ b/src/renderer/tool/impl/element/ellipse.cljs
@@ -19,8 +19,8 @@
 
 (defn create-el
   [db]
-  (let [fill (document.handlers/attr db :fill)
-        stroke (document.handlers/attr db :stroke)
+  (let [attrs (-> (document.handlers/attrs db)
+                  (select-keys [:stroke :fill :stroke-width]))
         [offset-x offset-y] (tool.handlers/snapped-offset db)
         [x y] (tool.handlers/snapped-position db)
         [rx ry] (->> [(abs (- x offset-x)) (abs (- y offset-y))]
@@ -29,12 +29,10 @@
         (tool.handlers/set-state :create)
         (element.handlers/add {:type :element
                                :tag :ellipse
-                               :attrs {:rx rx
-                                       :ry ry
-                                       :cx x
-                                       :cy y
-                                       :fill fill
-                                       :stroke stroke}}))))
+                               :attrs (merge attrs {:rx rx
+                                                    :ry ry
+                                                    :cx x
+                                                    :cy y})}))))
 
 (defn update-el
   [db e]

--- a/src/renderer/tool/impl/element/line.cljs
+++ b/src/renderer/tool/impl/element/line.cljs
@@ -22,16 +22,16 @@
   [db]
   (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
         [x y] (tool.handlers/snapped-position db)
-        stroke (document.handlers/attr db :stroke)]
+        attrs (-> (document.handlers/attrs db)
+                  (select-keys [:stroke :stroke-width]))]
     (-> db
         (tool.handlers/set-state :create)
         (element.handlers/add {:type :element
                                :tag :line
-                               :attrs {:x1 offset-x
-                                       :y1 offset-y
-                                       :x2 x
-                                       :y2 y
-                                       :stroke stroke}}))))
+                               :attrs (merge attrs {:x1 offset-x
+                                                    :y1 offset-y
+                                                    :x2 x
+                                                    :y2 y})}))))
 
 (defn update-el
   [db e]

--- a/src/renderer/tool/impl/element/path.cljs
+++ b/src/renderer/tool/impl/element/path.cljs
@@ -66,17 +66,17 @@
 (m/=> create-el [:-> App App])
 (defn create-el
   [db]
-  (let [[x y] (->> (tool.handlers/snapped-offset db)
-                   (mapv utils.length/->fixed))
-        stroke (document.handlers/attr db :stroke)
-        fill (document.handlers/attr db :fill)]
+  (let [path (->> (tool.handlers/snapped-offset db)
+                  (mapv utils.length/->fixed)
+                  (into ["M"])
+                  (string/join " "))
+        attrs (-> (document.handlers/attrs db)
+                  (select-keys [:stroke :fill :stroke-width]))]
     (-> db
         (tool.handlers/set-state :create)
         (element.handlers/add {:type :element
                                :tag :path
-                               :attrs {:d (string/join " " ["M" x y])
-                                       :stroke stroke
-                                       :fill fill}}))))
+                               :attrs (assoc attrs :d path)}))))
 
 (defmethod tool.hierarchy/on-pointer-up [::path :idle]
   [db _e]

--- a/src/renderer/tool/impl/element/polygon.cljs
+++ b/src/renderer/tool/impl/element/polygon.cljs
@@ -26,16 +26,15 @@
 
 (defmethod tool.hierarchy/on-pointer-up [::polygon :idle]
   [db _e]
-  (let [stroke (document.handlers/attr db :stroke)
-        fill (document.handlers/attr db :fill)
-        initial-point (tool.handlers/snapped-position db)]
+  (let [initial-point (tool.handlers/snapped-position db)
+        attrs (-> (document.handlers/attrs db)
+                  (select-keys [:stroke :fill :stroke-width])
+                  (assoc :points (string/join " " initial-point)))]
     (-> db
         (tool.handlers/set-state :create)
         (element.handlers/add {:type :element
                                :tag :polygon
-                               :attrs {:points (string/join " " initial-point)
-                                       :stroke stroke
-                                       :fill fill}}))))
+                               :attrs attrs}))))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/polygon

--- a/src/renderer/tool/impl/element/polyline.cljs
+++ b/src/renderer/tool/impl/element/polyline.cljs
@@ -26,16 +26,15 @@
 
 (defmethod tool.hierarchy/on-pointer-up [::polyline :idle]
   [db _e]
-  (let [stroke (document.handlers/attr db :stroke)
-        fill (document.handlers/attr db :fill)
-        initial-point (tool.handlers/snapped-position db)]
+  (let [initial-point (tool.handlers/snapped-position db)
+        attrs (-> (document.handlers/attrs db)
+                  (select-keys [:stroke :fill :stroke-width])
+                  (assoc :points (string/join " " initial-point)))]
     (-> db
         (tool.handlers/set-state :create)
         (element.handlers/add {:type :element
                                :tag :polyline
-                               :attrs {:points (string/join " " initial-point)
-                                       :stroke stroke
-                                       :fill fill}}))))
+                               :attrs attrs}))))
 
 (rf/dispatch [::action.events/register-action
               {:id :tool/polyline

--- a/src/renderer/tool/impl/element/rect.cljs
+++ b/src/renderer/tool/impl/element/rect.cljs
@@ -20,8 +20,8 @@
 
 (defn create-el
   [db]
-  (let [fill (document.handlers/attr db :fill)
-        stroke (document.handlers/attr db :stroke)
+  (let [attrs (-> (document.handlers/attrs db)
+                  (select-keys [:stroke :fill :stroke-width]))
         [offset-x offset-y] (tool.handlers/snapped-offset db)
         [x y] (tool.handlers/snapped-position db)
         [width height] (mapv (comp utils.length/->fixed abs)
@@ -34,12 +34,10 @@
         (tool.handlers/set-state :create)
         (element.handlers/add {:type :element
                                :tag :rect
-                               :attrs {:x x
-                                       :y y
-                                       :width width
-                                       :height height
-                                       :fill fill
-                                       :stroke stroke}}))))
+                               :attrs (merge attrs {:x x
+                                                    :y y
+                                                    :width width
+                                                    :height height})}))))
 
 (defn update-el
   [db e]

--- a/src/renderer/tool/impl/extension/blob.cljs
+++ b/src/renderer/tool/impl/extension/blob.cljs
@@ -20,25 +20,23 @@
 (defn attributes
   [db]
   (let [[offset-x offset-y] (tool.handlers/snapped-offset db)
-        radius (pointer-delta db)]
-    {:x (utils.length/->fixed (- offset-x radius))
-     :y (utils.length/->fixed (- offset-y radius))
-     :size (utils.length/->fixed (* radius 2))}))
+        radius (pointer-delta db)
+        attrs (-> (document.handlers/attrs db)
+                  (select-keys [:stroke :fill :stroke-width]))]
+    (merge attrs {:x (utils.length/->fixed (- offset-x radius))
+                  :y (utils.length/->fixed (- offset-y radius))
+                  :size (utils.length/->fixed (* radius 2))})))
 
 (defmethod tool.hierarchy/on-drag-start [::blob :idle]
   [db _e]
-  (let [fill (document.handlers/attr db :fill)
-        stroke (document.handlers/attr db :stroke)
-        seed (rand-int 1000000)]
+  (let [seed (rand-int 1000000)]
     (-> (tool.handlers/set-state db :create)
         (element.handlers/add {:type :element
                                :tag :blob
                                :attrs (merge (attributes db)
                                              {:seed seed
                                               :extraPoints 8
-                                              :randomness 4
-                                              :fill fill
-                                              :stroke stroke})}))))
+                                              :randomness 4})}))))
 
 (defmethod tool.hierarchy/on-drag [::blob :create]
   [db _e]

--- a/src/renderer/toolbar/status.cljs
+++ b/src/renderer/toolbar/status.cljs
@@ -14,6 +14,8 @@
    [renderer.input.subs :as-alias input.subs]
    [renderer.snap.views :as snap.views]
    [renderer.timeline.views :as timeline.views]
+   [renderer.tool.hierarchy :as tool.hierarchy]
+   [renderer.tool.subs :as-alias tool.subs]
    [renderer.utils.key :as utils.key]
    [renderer.utils.length :as utils.length]
    [renderer.views :as views]
@@ -152,8 +154,8 @@
        [views/popover-arrow]]]]))
 
 (defn color-selectors []
-  (let [fill @(rf/subscribe [::document.subs/fill])
-        stroke @(rf/subscribe [::document.subs/stroke])
+  (let [fill @(rf/subscribe [::document.subs/attr :fill])
+        stroke @(rf/subscribe [::document.subs/attr :stroke])
         get-hex #(:hex (js->clj % :keywordize-keys true))]
     [:div.flex
      {:class "gap-0.5"}
@@ -190,11 +192,17 @@
 
 (defn root []
   (let [md? @(rf/subscribe [::window.subs/md?])
-        zoom @(rf/subscribe [::document.subs/zoom])]
+        zoom @(rf/subscribe [::document.subs/zoom])
+        active-tool @(rf/subscribe [::tool.subs/cached-or-active])
+        sm? @(rf/subscribe [::window.subs/sm?])]
     [views/toolbar
      {:class "bg-primary relative justify-center md:justify-start py-2 md:py-1
               gap-2 md:gap-1"}
      [color-selectors]
+     (when (and sm? (get-method tool.hierarchy/tool-options active-tool))
+       [:<>
+        [:div.v-divider]
+        [tool.hierarchy/tool-options active-tool]])
      [:div.grow.hidden.md:block]
      (when md?
        [:<>

--- a/test/document_test.cljs
+++ b/test/document_test.cljs
@@ -119,8 +119,8 @@
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
 
-   (let [fill (rf/subscribe [::document.subs/fill])
-         stroke (rf/subscribe [::document.subs/stroke])]
+   (let [fill (rf/subscribe [::document.subs/attr :fill])
+         stroke (rf/subscribe [::document.subs/attr :stroke])]
      (testing "default color values"
        (is (= @fill "lightgray"))
        (is (= @stroke "black")))

--- a/test/document_test.cljs
+++ b/test/document_test.cljs
@@ -120,10 +120,12 @@
    (rf/dispatch [::app.events/initialize])
 
    (let [fill (rf/subscribe [::document.subs/attr :fill])
-         stroke (rf/subscribe [::document.subs/attr :stroke])]
+         stroke (rf/subscribe [::document.subs/attr :stroke])
+         stroke-width (rf/subscribe [::document.subs/attr :stroke-width])]
      (testing "default color values"
        (is (= @fill "lightgray"))
-       (is (= @stroke "black")))
+       (is (= @stroke "black"))
+       (is (= @stroke-width "1px")))
 
      (testing "swap colors"
        (rf/dispatch [::document.events/swap-colors])


### PR DESCRIPTION
This PR introduces options on the bottom toolbar for active tools. Those settings are document specific and persisted. #27 (attribute locking) was also handled here. The rationale was that the only attributes that needed to be locked are `width` and `height`. Preserving the aspect ratio is also an option that make sense for elements that don't support those attributes. With that in mind, making aspect ratio locking a tool option of the transform tool made more sense. For now, a `stroke-width` option for element tools, and a `lock-aspect-ratio` fro the transform tool were introduced.

https://github.com/user-attachments/assets/83b2d87b-3782-4a28-a941-a73313482bbd

Resolves #54
Resolves #27

## Technical details

We are used the existing document attributes to store the added options. That makes the document specific and persisted by default. Migrating grid and ruler visibility to document attributes, looks like a good idea.