### PR TITLE
Mobile drawer enhancements

### DIFF
--- a/src/renderer/app/views.cljs
+++ b/src/renderer/app/views.cljs
@@ -298,53 +298,39 @@
 
 (defn bottom-bar
   []
-  (let [some-selected? @(rf/subscribe [::element.subs/some-selected?])
-        mac? @(rf/subscribe [::app.subs/mac?])]
+  (let [some-selected? @(rf/subscribe [::element.subs/some-selected?])]
     [:div.flex.justify-evenly.p-2.gap-1.rtl:flex-row-reverse
 
      [views/drawer
       {:icon "tree"
-       :label [::tree "Tree"]
-       :direction "left"
-       :content-class (when mac? "pt-8")}
+       :label [::tree "Tree"]}
       [tree.views/root]]
 
      [views/drawer
       {:icon "code"
-       :label [::xml "XML"]
-       :direction "left"
-       :content-class (when mac? "pt-8")}
+       :label [::xml "XML"]}
       [views/scroll-area
-       [:div.py-3
-        [xml-panel]]]]
-
-     [:span.v-divider]
+       [:div.py-3 [xml-panel]]]]
 
      [views/drawer
       {:icon "animation"
-       :label [::timeline "Timeline"]
-       :direction "bottom"}
+       :label [::timeline "Timeline"]}
       [timeline.views/root]]
 
      [views/drawer
       {:icon "shell"
-       :label [::shell "Shell"]
-       :direction "bottom"}
+       :label [::shell "Shell"]}
       [:div.flex.flex-col.flex-1
        [repl.views/root]]]
 
-     [:span.v-divider]
-
      [views/drawer
       {:icon "history"
-       :label [::history "History"]
-       :direction "right"}
+       :label [::history "History"]}
       [history.views/root]]
 
      [views/drawer
       {:icon "properties"
        :label [::attributes "Attributes"]
-       :direction "right"
        :disabled (not some-selected?)}
       [attributes-panel]]]))
 

--- a/src/renderer/views.cljs
+++ b/src/renderer/views.cljs
@@ -345,51 +345,32 @@
       message]]]])
 
 (defn drawer
-  [{:keys [label direction disabled snap-points content-class]
+  [{:keys [label disabled]
     :as attrs} & children]
-  (reagent/with-let [snap (reagent/atom nil)]
-    [:> Drawer.Root
-     (cond-> {:direction direction}
-       snap-points
-       (assoc :snapPoints (clj->js snap-points)
-              :activeSnapPoint @snap
-              :setActiveSnapPoint (fn [v] (reset! snap v))))
-     [:> Drawer.Trigger
-      {:class "button p-1 rounded h-auto flex flex-col flex-1 text-2xs gap-1
-               overflow-hidden items-center"
-       :disabled disabled}
-      [icon (:icon attrs)]
-      [:span.truncate.w-full (i18n.views/t label)]]
-     [:> Drawer.Portal
-      [:> Drawer.Overlay
-       {:class "backdrop"}]
-      [:> Drawer.Content
-       {:class ["inset-0 fixed z-0 outline-none bg-primary flex shadow-lg"
-                (case direction
-                  "left"
-                  "right-auto max-w-[80dvw] min-w-[60dvw] py-safe pl-safe"
-
-                  "right"
-                  "left-auto max-w-[80dvw] min-w-[60dvw] py-safe pr-safe"
-
-                  "bottom"
-                  "top-auto max-h-[60dvh] min-h-[30dvh] px-safe pb-safe"
-
-                  "top"
-                  "bottom-auto max-h-[60dvh] min-h-[30dvh] px-safe pt-safe")
-                content-class]
-        :style {:margin (cond
-                          (or (= direction "left")
-                              (= direction "right"))
-                          "- env(safe-area-inset-top) 0
-                           - env(safe-area-inset-bottom) 0"
-
-                          :else
-                          "0 - env(safe-area-inset-right)
-                           0 - env(safe-area-inset-left)")}}
-       [:> Drawer.Title {:class "sr-only"} (i18n.views/t label)]
-       [:> Drawer.Description
-        {:as-child true}
-        (into [:div.flex.flex-1.overflow-hidden
-               {:class (when (= direction "bottom") "w-full")}]
-              children)]]]]))
+  [:> Drawer.Root
+   {:direction "bottom"
+    :modal false}
+   [:> Drawer.Trigger
+    {:class "button p-1 rounded h-auto flex flex-col flex-1 text-2xs gap-1
+             overflow-hidden items-center"
+     :disabled disabled}
+    [icon (:icon attrs)]
+    [:span.truncate.w-full (i18n.views/t label)]]
+   [:> Drawer.Portal
+    [:> Drawer.Content
+     {:class "inset-0 fixed z-0 outline-none bg-primary flex shadow-lg
+              flex-col items-center top-auto px-safe pb-safe rounded-t-xl
+              h-[30dvh] overflow-hidden"
+      :style {:margin "0 - env(safe-area-inset-right)
+                       0 - env(safe-area-inset-left)"
+              :box-shadow "0 -10px 15px -3px
+                           var(--tw-shadow-color, rgb(0 0 0 / 0.1)),
+                           0 -4px 6px -4px
+                           var(--tw-shadow-color, rgb(0 0 0 / 0.1))"}}
+     [:div.mx-auto.my-3.w-12.rounded-full.bg-overlay
+      {:class "h-1.5"
+       :aria-hidden true}]
+     [:> Drawer.Title
+      {:class "sr-only"}
+      (i18n.views/t label)]
+     (into [:div.flex.flex-1.overflow-hidden.w-full] children)]]])


### PR DESCRIPTION
The drawer component is simplified and always slides from the bottom. The overlay is removed, and `modal` is set to false to allow interacting with the canvas while the drawer is open. Snap points could be useful, but they don't seem to play nice with overflowing content.  A handle was added to help users handle the drawer when the content is scrollable. The separators between the triggers were also removed.

https://github.com/user-attachments/assets/9f36c8ec-258c-4d37-ae30-4537dd519f46