### PR TITLE
Add brush size tool option and adjust size on ctrl down

### DIFF
--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -591,7 +591,10 @@
 
  :renderer.tool.impl.draw.brush
  {:label "فرشاة"
-  :draw-brush "رسم بالفرشاة"}
+  :draw-brush "رسم بالفرشاة"
+  :brush-size "حجم الفرشاة"
+  :drag-to-draw [:div "انقر واسحب للرسم بالفرشاة."]
+  :hold-ctrl-to-adjust-size [:div "اضغط مع الاستمرار على %1 لضبط حجم الفرشاة."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "قلم"

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -636,7 +636,11 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Pinsel"
-  :draw-brush "Mit Pinsel zeichnen"}
+  :draw-brush "Pinseln"
+  :brush-size "Pinselgröße"
+  :drag-to-draw [:div "Klicken und ziehen zum Pinseln."]
+  :hold-ctrl-to-adjust-size [:div "Halten Sie %1 gedrückt, um die Pinselgröße
+                                   anzupassen."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Stift"

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -640,7 +640,11 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Πινέλο"
-  :draw-brush "Πινέλο σχεδίασης"}
+  :draw-brush "Βούρτσισμα"
+  :brush-size "Μέγεθος πινέλου"
+  :drag-to-draw [:div "Κάντε κλικ και σύρετε για να πινελίσετε."]
+  :hold-ctrl-to-adjust-size [:div "Κρατήστε %1 για να ρυθμίσετε το μέγεθος του
+                                   πινέλου."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Στυλό"

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -604,7 +604,10 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Brush"
-  :draw-brush "Draw brush"}
+  :draw-brush "Brush"
+  :brush-size "Brush size"
+  :drag-to-draw [:div "Click and drag to brush."]
+  :hold-ctrl-to-adjust-size [:div "Hold %1 to adjust the brush size."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Pen"

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -620,7 +620,11 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Pincel"
-  :draw-brush "Dibujar con pincel"}
+  :draw-brush "Pincelar"
+  :brush-size "Tamaño del pincel"
+  :drag-to-draw [:div "Haz clic y arrastra para pincelar."]
+  :hold-ctrl-to-adjust-size [:div "Mantén %1 para ajustar el tamaño del
+                                   pincel."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Pluma"

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -627,7 +627,11 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Pinceau"
-  :draw-brush "Dessiner au pinceau"}
+  :draw-brush "Brosser"
+  :brush-size "Taille du pinceau"
+  :drag-to-draw [:div "Cliquez et faites glisser pour brosser."]
+  :hold-ctrl-to-adjust-size [:div "Maintenez %1 pour ajuster la taille du
+                                   pinceau."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Stylo"

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -632,7 +632,11 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Pennello"
-  :draw-brush "Disegna pennello"}
+  :draw-brush "Pennellare"
+  :brush-size "Dimensione del pennello"
+  :drag-to-draw [:div "Fai clic e trascina per pennellare."]
+  :hold-ctrl-to-adjust-size [:div "Tieni premuto %1 per regolare la dimensione
+                                   del pennello."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Penna"

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -576,7 +576,10 @@
 
  :renderer.tool.impl.draw.brush
  {:label "ブラシ"
-  :draw-brush "ブラシで描画"}
+  :draw-brush "ブラシで描く"
+  :brush-size "ブラシサイズ"
+  :drag-to-draw [:div "クリックしてドラッグしてブラシをかけます。"]
+  :hold-ctrl-to-adjust-size [:div "%1 を押しながらブラシサイズを調整します。"]}
 
  :renderer.tool.impl.draw.pencil
  {:label "ペン"

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -572,7 +572,10 @@
 
  :renderer.tool.impl.draw.brush
  {:label "브러시"
-  :draw-brush "브러시 그리기"}
+  :draw-brush "브러시로 그리기"
+  :brush-size "브러시 크기"
+  :drag-to-draw [:div "클릭하고 드래그하여 브러시를 사용하세요."]
+  :hold-ctrl-to-adjust-size [:div "%1 을 누른 채로 브러시 크기를 조정하세요."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "펜"

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -633,7 +633,11 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Penseel"
-  :draw-brush "Penseel tekenen"}
+  :draw-brush "Penselen"
+  :brush-size "Penseelgrootte"
+  :drag-to-draw [:div "Klik en sleep om te penselen."]
+  :hold-ctrl-to-adjust-size [:div "Houd %1 ingedrukt om de penseelgrootte aan
+                                   te passen."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Pen"

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -615,7 +615,11 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Pincel"
-  :draw-brush "Desenhar com pincel"}
+  :draw-brush "Pincelar"
+  :brush-size "Tamanho do pincel"
+  :drag-to-draw [:div "Clique e arraste para pincelar."]
+  :hold-ctrl-to-adjust-size [:div "Segure %1 para ajustar o tamanho do
+                                   pincel."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Caneta"

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -616,7 +616,11 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Кисть"
-  :draw-brush "Рисовать кистью"}
+  :draw-brush "Рисовать кистью"
+  :brush-size "Размер кисти"
+  :drag-to-draw [:div "Нажмите и перетащите для рисования кистью."]
+  :hold-ctrl-to-adjust-size [:div "Удерживайте %1, чтобы изменить размер
+                                   кисти."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Перо"

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -618,7 +618,11 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Pensel"
-  :draw-brush "Rita pensel"}
+  :draw-brush "Pensla"
+  :brush-size "Penselstorlek"
+  :drag-to-draw [:div "Klicka och dra för att pensla."]
+  :hold-ctrl-to-adjust-size [:div "Håll %1 intryckt för att justera
+                                   penselstorlek."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Penna"

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -611,7 +611,11 @@
 
  :renderer.tool.impl.draw.brush
  {:label "Fırça"
-  :draw-brush "Fırça çiz"}
+  :draw-brush "Fırçala"
+  :brush-size "Fırça boyutu"
+  :drag-to-draw [:div "Fırçalamak için tıklayın ve sürükleyin."]
+  :hold-ctrl-to-adjust-size [:div "Fırça boyutunu ayarlamak için %1 tuşunu
+                                   basılı tutun."]}
 
  :renderer.tool.impl.draw.pencil
  {:label "Kalem"

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -537,7 +537,10 @@
 
  :renderer.tool.impl.draw.brush
  {:label "画笔"
-  :draw-brush "画笔绘制"}
+  :draw-brush "用画笔绘制"
+  :brush-size "画笔大小"
+  :drag-to-draw [:div "单击并拖动以使用画笔。"]
+  :hold-ctrl-to-adjust-size [:div "按住 %1 调整画笔大小。"]}
 
  :renderer.tool.impl.draw.pencil
  {:label "钢笔"

--- a/src/renderer/document/db.cljs
+++ b/src/renderer/document/db.cljs
@@ -42,7 +42,8 @@
    [:centered {:optional true} boolean?]
    [:attrs {:default {:fill "lightgray"
                       :stroke "black"
-                      :stroke-width "1px"}} DocumentAttrs]
+                      :stroke-width "1px"
+                      :brush-size 16}} DocumentAttrs]
    [:preview-label {:optional true} string?]
    [:file-handle {:optional true} JS_Object]])
 

--- a/src/renderer/document/events.cljs
+++ b/src/renderer/document/events.cljs
@@ -70,6 +70,7 @@
 
 (rf/reg-event-db
  ::set-attr
+ [persist]
  (fn [db [_ k v]]
    (document.handlers/assoc-attr db k v)))
 
@@ -82,9 +83,7 @@
 (rf/reg-event-db
  ::preview-attr
  (fn [db [_ k v]]
-   (-> db
-       (document.handlers/assoc-attr k v)
-       (element.handlers/set-attr k v))))
+   (document.handlers/assoc-attr db k v)))
 
 (rf/reg-event-fx
  ::close

--- a/src/renderer/tool/impl/draw/brush.cljs
+++ b/src/renderer/tool/impl/draw/brush.cljs
@@ -7,16 +7,20 @@
    [reagent.core :as reagent]
    [renderer.action.events :as-alias action.events]
    [renderer.app.handlers :as app.handlers]
+   [renderer.document.events :as-alias document.events]
    [renderer.document.handlers :as document.handlers]
+   [renderer.document.subs :as-alias document.subs]
    [renderer.element.handlers :as element.handlers]
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
+   [renderer.i18n.views :as i18n.views]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
    [renderer.tool.subs :as-alias tool.subs]
-   [renderer.utils.key :as utils.key]))
+   [renderer.utils.key :as utils.key]
+   [renderer.views :as views]))
 
 (hierarchy/derive! ::brush ::tool.hierarchy/draw)
 
@@ -27,12 +31,30 @@
  (fn [value]
    (reset! brush value)))
 
+(defmethod tool.hierarchy/tool-options ::brush
+  []
+  (let [brush-size @(rf/subscribe [::document.subs/attr :brush-size])]
+    [:div.flex.items-center.gap-2
+     [:span
+      brush-size]
+     [views/slider
+      {:min 1
+       :max 100
+       :step 1
+       :title (i18n.views/t [::brush-size "Brush Size"])
+       :value [brush-size]
+       :class "w-32"
+       :on-value-change (fn [[v]]
+                          (rf/dispatch [::document.events/set-attr
+                                        :brush-size v]))}]]))
+
 (defmethod tool.hierarchy/on-pointer-move [::brush :idle]
   [db e]
-  (let [[x y] (:adjusted-pointer-pos db)
+  (let [brush-size (document.handlers/attr db :brush-size)
+        [x y] (:adjusted-pointer-pos db)
         pressure (:pressure e)
         pressure (if (zero? pressure) 1 pressure)
-        r (* (/ 16 2) pressure)
+        r (* (/ brush-size 2) pressure)
         fill (document.handlers/attr db :fill)]
     (app.handlers/add-fx db [::set-brush {:type :element
                                           :tag :circle
@@ -43,7 +65,8 @@
 
 (defmethod tool.hierarchy/on-drag-start [::brush :idle]
   [db e]
-  (let [point (string/join " " (conj (:adjusted-pointer-pos db) (:pressure e)))
+  (let [brush-size (document.handlers/attr db :brush-size)
+        point (string/join " " (conj (:adjusted-pointer-pos db) (:pressure e)))
         fill (document.handlers/attr db :fill)]
     (-> db
         (tool.handlers/set-state :create)
@@ -51,7 +74,7 @@
                                :tag :brush
                                :attrs {:points point
                                        :fill fill
-                                       :size 16
+                                       :size brush-size
                                        :thinning 0.5
                                        :smoothing 0.5
                                        :streamline 0.5}}))))

--- a/src/renderer/tool/impl/draw/brush.cljs
+++ b/src/renderer/tool/impl/draw/brush.cljs
@@ -51,8 +51,9 @@
 (defmethod tool.hierarchy/help [::brush :idle]
   []
   [:<>
-   (i18n.views/t [::idle-draw [:div "Click and drag to draw."]])
-   (i18n.views/t [::idle-hold [:div "Hold %1 to adjust brush size."]]
+   (i18n.views/t [::drag-to-draw [:div "Click and drag to brush."]])
+   (i18n.views/t [::hold-ctrl-to-adjust-size
+                  [:div "Hold %1 to adjust the brush size."]]
                  [[views/kbd "Ctrl"]])])
 
 (defmethod tool.hierarchy/tool-options ::brush
@@ -65,7 +66,7 @@
       {:min min-size
        :max max-size
        :step 1
-       :title (i18n.views/t [::brush-size "Brush Size"])
+       :title (i18n.views/t [::brush-size "Brush size"])
        :value [brush-size]
        :class "w-32"
        :on-value-change (fn [[v]]
@@ -135,7 +136,7 @@
 (defmethod tool.hierarchy/on-drag-end [::brush :create]
   [db e]
   (-> db
-      (history.handlers/finalize (:timestamp e) [::draw-brush "Draw brush"])
+      (history.handlers/finalize (:timestamp e) [::draw-brush "Brush"])
       (tool.handlers/deactivate)))
 
 (defmethod tool.hierarchy/render ::brush

--- a/src/renderer/tool/impl/draw/brush.cljs
+++ b/src/renderer/tool/impl/draw/brush.cljs
@@ -15,6 +15,7 @@
    [renderer.hierarchy :as hierarchy]
    [renderer.history.handlers :as history.handlers]
    [renderer.i18n.views :as i18n.views]
+   [renderer.input.handlers :as input.handlers]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.handlers :as tool.handlers]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -26,10 +27,33 @@
 
 (defonce brush (reagent/atom nil))
 
+(def min-size 1)
+(def max-size 100)
+
 (rf/reg-fx
  ::set-brush
  (fn [value]
    (reset! brush value)))
+
+(rf/reg-fx
+ ::set-brush-size
+ (fn [value]
+   (reset! brush {:type :element
+                  :tag :circle
+                  :attrs (assoc (:attrs @brush)
+                                :r (/ value 2))})))
+
+(defn update-brush-size
+  [db]
+  (let [brush-size (document.handlers/attr db :brush-size)]
+    (app.handlers/add-fx db [::set-brush-size brush-size])))
+
+(defmethod tool.hierarchy/help [::brush :idle]
+  []
+  [:<>
+   (i18n.views/t [::idle-draw [:div "Click and drag to draw."]])
+   (i18n.views/t [::idle-hold [:div "Hold %1 to adjust brush size."]]
+                 [[views/kbd "Ctrl"]])])
 
 (defmethod tool.hierarchy/tool-options ::brush
   []
@@ -38,8 +62,8 @@
      [:span
       brush-size]
      [views/slider
-      {:min 1
-       :max 100
+      {:min min-size
+       :max max-size
        :step 1
        :title (i18n.views/t [::brush-size "Brush Size"])
        :value [brush-size]
@@ -49,35 +73,55 @@
                                         :brush-size v]))}]]))
 
 (defmethod tool.hierarchy/on-pointer-move [::brush :idle]
-  [db e]
+  [db _e]
   (let [brush-size (document.handlers/attr db :brush-size)
         [x y] (:adjusted-pointer-pos db)
-        pressure (:pressure e)
-        pressure (if (zero? pressure) 1 pressure)
-        r (* (/ brush-size 2) pressure)
         fill (document.handlers/attr db :fill)]
     (app.handlers/add-fx db [::set-brush {:type :element
                                           :tag :circle
                                           :attrs {:cx x
                                                   :cy y
-                                                  :r r
+                                                  :r (/ brush-size 2)
                                                   :fill fill}}])))
+
+(defn adjust-size?
+  [db e]
+  (or (:ctrl-key e)
+      (input.handlers/multi-touch? db)))
 
 (defmethod tool.hierarchy/on-drag-start [::brush :idle]
   [db e]
   (let [brush-size (document.handlers/attr db :brush-size)
         point (string/join " " (conj (:adjusted-pointer-pos db) (:pressure e)))
         fill (document.handlers/attr db :fill)]
-    (-> db
-        (tool.handlers/set-state :create)
-        (element.handlers/add {:type :element
-                               :tag :brush
-                               :attrs {:points point
-                                       :fill fill
-                                       :size brush-size
-                                       :thinning 0.5
-                                       :smoothing 0.5
-                                       :streamline 0.5}}))))
+    (if (adjust-size? db e)
+      (assoc db :last-origin (:pointer-pos e))
+      (-> db
+          (tool.handlers/set-state :create)
+          (element.handlers/add {:type :element
+                                 :tag :brush
+                                 :attrs {:points point
+                                         :fill fill
+                                         :size brush-size
+                                         :thinning 0.5
+                                         :smoothing 0.5
+                                         :streamline 0.5}})))))
+
+(defmethod tool.hierarchy/on-drag [::brush :idle]
+  [db e]
+  (cond-> db
+    (adjust-size? db e)
+    (-> (document.handlers/update-attr
+         :brush-size
+         (fn [size]
+           (let [{:keys [last-origin]} db
+                 [delta-x delta-y] (matrix/sub (:pointer-pos e) last-origin)
+                 delta (if (> (abs delta-x) (abs delta-y)) delta-x (- delta-y))]
+             (if (pos? delta)
+               (min max-size (inc size))
+               (max min-size (dec size))))))
+        (update-brush-size)
+        (assoc :last-origin (:pointer-pos e)))))
 
 (defmethod tool.hierarchy/on-drag [::brush :create]
   [db e]

--- a/src/renderer/toolbar/status.cljs
+++ b/src/renderer/toolbar/status.cljs
@@ -7,7 +7,6 @@
    [renderer.action.views :as action.views]
    [renderer.document.events :as-alias document.events]
    [renderer.document.subs :as-alias document.subs]
-   [renderer.element.events :as-alias element.events]
    [renderer.frame.events :as-alias frame.events]
    [renderer.i18n.views :as i18n.views]
    [renderer.input.subs :as-alias input.subs]

--- a/src/renderer/toolbar/status.cljs
+++ b/src/renderer/toolbar/status.cljs
@@ -139,7 +139,7 @@
      {:class "gap-0.5"}
      [color-picker
       {:color fill
-       :on-change-complete #(rf/dispatch [::element.events/set-attr :fill
+       :on-change-complete #(rf/dispatch [::document.events/set-attr :fill
                                           (get-hex %)])
        :on-change #(rf/dispatch [::document.events/preview-attr :fill
                                  (get-hex %)])}
@@ -156,7 +156,7 @@
 
      [color-picker
       {:color stroke
-       :on-change-complete #(rf/dispatch [::element.events/set-attr
+       :on-change-complete #(rf/dispatch [::document.events/set-attr
                                           :stroke
                                           (get-hex %)])
        :on-change #(rf/dispatch [::document.events/preview-attr


### PR DESCRIPTION
This PR introduces a brush size slider option and also allows users to adjust the size by holding `Ctrl` while dragging. We also don't update the selected elements fill or stroke when we change the document fill and stroke attributes.

https://github.com/user-attachments/assets/8fe89064-f815-4157-8cbc-7125859608a1