### PR TITLE
Take stroke width into account when calculating bounding boxes

### DIFF
--- a/src/renderer/element/impl/box.cljs
+++ b/src/renderer/element/impl/box.cljs
@@ -78,12 +78,12 @@
   (let [{{:keys [width height]} :attrs} el]
     (apply * (map utils.length/unit->px [width height]))))
 
-#_(defmethod hierarchy/snapping-points ::element.hierarchy/box
-    [el]
-    (let [{{:keys [x y width height]} :attrs} el
-          [x y w h] (mapv utils.length/unit->px [x y width height])]
-      (mapv #(with-meta % {:label [::box-corner "box corner"]})
-            [[x y]
-             [(+ x w) y]
-             [(+ x w) (+ y h)]
-             [x (+ y h)]])))
+(defmethod element.hierarchy/snapping-points ::element.hierarchy/box
+  [el]
+  (let [{{:keys [x y width height]} :attrs} el
+        [x y w h] (mapv utils.length/unit->px [x y width height])]
+    (mapv #(with-meta % {:label [::box-corner "box corner"]})
+          [[x y]
+           [(+ x w) y]
+           [(+ x w) (+ y h)]
+           [x (+ y h)]])))

--- a/src/renderer/element/impl/box.cljs
+++ b/src/renderer/element/impl/box.cljs
@@ -6,6 +6,7 @@
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.hierarchy :as hierarchy]
    [renderer.input.handlers :as input.handlers]
+   [renderer.tool.impl.element.core :as-alias element.core]
    [renderer.utils.element :as utils.element]
    [renderer.utils.length :as utils.length]))
 
@@ -82,7 +83,7 @@
   [el]
   (let [{{:keys [x y width height]} :attrs} el
         [x y w h] (mapv utils.length/unit->px [x y width height])]
-    (mapv #(with-meta % {:label [::box-corner "box corner"]})
+    (mapv #(with-meta % {:label [::element.core/edge "edge"]})
           [[x y]
            [(+ x w) y]
            [(+ x w) (+ y h)]

--- a/src/renderer/element/impl/container/canvas.cljs
+++ b/src/renderer/element/impl/container/canvas.cljs
@@ -106,11 +106,11 @@
      (when grid?
        [ruler.views/grid])
 
-     (when (and snap? (not= state :select))
-       [snap-info])
-
      (when-not read-only?
-       [tool.hierarchy/render active-tool])]))
+       [tool.hierarchy/render active-tool])
+
+     (when (and snap? (not= state :select))
+       [snap-info])]))
 
 (defmethod element.hierarchy/render-to-string :canvas
   [el]

--- a/src/renderer/element/impl/shape/circle.cljs
+++ b/src/renderer/element/impl/shape/circle.cljs
@@ -7,6 +7,7 @@
    [renderer.attribute.hierarchy :as attribute.hierarchy]
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.hierarchy :as hierarchy]
+   [renderer.tool.impl.element.core :as-alias element.core]
    [renderer.utils.bounds :as utils.bounds]
    [renderer.utils.element :as utils.element]
    [renderer.utils.length :as utils.length]
@@ -115,7 +116,7 @@
   [el]
   (let [{{:keys [cx cy r]} :attrs} el
         [cx cy r] (mapv utils.length/unit->px [cx cy r])]
-    (mapv #(with-meta % {:label [::circle-edge "circle edge"]})
+    (mapv #(with-meta % {:label [::element.core/edge "edge"]})
           [[(- cx r) cy]
            [(+ cx r) cy]
            [cx (- cy r)]

--- a/src/renderer/element/impl/shape/circle.cljs
+++ b/src/renderer/element/impl/shape/circle.cljs
@@ -37,20 +37,25 @@
 
 (defmethod element.hierarchy/scale :circle
   [el ratio pivot-point]
-  (let [dimensions (-> el element.hierarchy/bbox utils.bounds/->dimensions)
+  (let [{{:keys [stroke-width]} :attrs} el
+        padding (/ (utils.length/unit->px stroke-width) 2)
+        dimensions (-> el element.hierarchy/bbox utils.bounds/->dimensions)
         pivot-point (->> (matrix/div dimensions 2)
                          (matrix/sub pivot-point))
         offset (utils.element/scale-offset ratio pivot-point)
         ratio (apply min ratio)]
     (-> el
-        (attribute.hierarchy/update-attr :r #(abs (* % ratio)))
+        (attribute.hierarchy/update-attr :r #(- (* (+ % padding) (abs ratio))
+                                                padding))
         (element.hierarchy/translate offset))))
 
 (defmethod element.hierarchy/bbox :circle
   [el]
-  (let [{{:keys [cx cy r]} :attrs} el
-        [cx cy r] (map utils.length/unit->px [cx cy r])]
-    [(- cx r) (- cy r) (+ cx r) (+ cy r)]))
+  (let [{{:keys [cx cy r stroke-width]} :attrs} el
+        [cx cy r stroke-width] (->> [cx cy r stroke-width]
+                                    (map utils.length/unit->px))
+        padding (/ stroke-width 2)]
+    [(- cx r padding) (- cy r padding) (+ cx r padding) (+ cy r padding)]))
 
 (defmethod element.hierarchy/area :circle
   [el]
@@ -81,9 +86,10 @@
 
 (defmethod element.hierarchy/handles :circle
   [el]
-  (let [bbox (:bbox el)
-        [cx cy] (utils.bounds/center bbox)
-        r (/ (first (utils.bounds/->dimensions bbox)) 2)]
+  (let [{{:keys [cx cy r]} :attrs} el
+        [cx cy r] (map utils.length/unit->px [cx cy r])
+        offset (utils.element/offset el)
+        [cx cy] (matrix/add [cx cy] offset)]
     [{:position [(+ cx r) cy]
       :id :r
       :label [::r-handle "radius handle"]
@@ -94,12 +100,23 @@
 
 (defmethod element.hierarchy/render-edit :circle
   [el]
-  (let [bbox (:bbox el)
-        [cx cy] (utils.bounds/center bbox)
-        r (/ (first (utils.bounds/->dimensions bbox)) 2)]
+  (let [{{:keys [cx cy r]} :attrs} el
+        [cx cy r] (map utils.length/unit->px [cx cy r])
+        offset (utils.element/offset el)
+        [cx cy] (matrix/add [cx cy] offset)]
     [:g
      [utils.svg/line [cx cy] [(+ cx r) cy] :stroke "var(--accent-foreground)"]
      [utils.svg/line [cx cy] [(+ cx r) cy] :stroke-dasharray 5]
      [utils.svg/label (utils.length/->fixed r 2 false) {:x (+ cx (/ r 2))
                                                         :y cy}]
      [utils.svg/times [cx cy]]]))
+
+(defmethod element.hierarchy/snapping-points :circle
+  [el]
+  (let [{{:keys [cx cy r]} :attrs} el
+        [cx cy r] (mapv utils.length/unit->px [cx cy r])]
+    (mapv #(with-meta % {:label [::circle-edge "circle edge"]})
+          [[(- cx r) cy]
+           [(+ cx r) cy]
+           [cx (- cy r)]
+           [cx (+ cy r)]])))

--- a/src/renderer/element/impl/shape/ellipse.cljs
+++ b/src/renderer/element/impl/shape/ellipse.cljs
@@ -38,22 +38,28 @@
 (defmethod element.hierarchy/scale :ellipse
   [el ratio pivot-point]
   (let [[x y] ratio
+        {{:keys [stroke-width]} :attrs} el
+        padding (/ (utils.length/unit->px stroke-width) 2)
         dimensions (-> el element.hierarchy/bbox utils.bounds/->dimensions)
+        update-size (fn [ratio size]
+                      (- (* (+ size padding) (abs ratio)) padding))
         pivot-point (->> (matrix/div dimensions 2)
                          (matrix/sub pivot-point))
         offset (utils.element/scale-offset ratio pivot-point)]
     (-> el
-        (attribute.hierarchy/update-attr :rx #(abs (* % x)))
-        (attribute.hierarchy/update-attr :ry #(abs (* % y)))
+        (attribute.hierarchy/update-attr :rx (partial update-size x))
+        (attribute.hierarchy/update-attr :ry (partial update-size y))
         (element.hierarchy/translate offset))))
 
 (defmethod element.hierarchy/bbox :ellipse
   [el]
-  (let [{{:keys [cx cy rx ry]} :attrs} el
+  (let [{{:keys [cx cy rx ry stroke-width]} :attrs} el
         rx (or rx ry)
         ry (or ry rx)
-        [cx cy rx ry] (map utils.length/unit->px [cx cy rx ry])]
-    [(- cx rx) (- cy ry) (+ cx rx) (+ cy ry)]))
+        [cx cy rx ry stroke-width] (->> [cx cy rx ry stroke-width]
+                                        (map utils.length/unit->px))
+        padding (/ stroke-width 2)]
+    [(- cx rx padding) (- cy ry padding) (+ cx rx padding) (+ cy ry padding)]))
 
 (defmethod element.hierarchy/path :ellipse
   [el]
@@ -89,9 +95,10 @@
 
 (defmethod element.hierarchy/handles :ellipse
   [el]
-  (let [bbox (:bbox el)
-        [cx cy] (utils.bounds/center bbox)
-        [rx ry] (matrix/div (utils.bounds/->dimensions bbox) 2)]
+  (let [{{:keys [cx cy rx ry]} :attrs} el
+        [cx cy rx ry] (mapv utils.length/unit->px [cx cy rx ry])
+        offset (utils.element/offset el)
+        [cx cy] (matrix/add [cx cy] offset)]
     [{:type :handle
       :action :edit
       :parent (:id el)
@@ -109,9 +116,10 @@
 
 (defmethod element.hierarchy/render-edit :ellipse
   [el]
-  (let [bbox (:bbox el)
-        [cx cy] (utils.bounds/center bbox)
-        [rx ry] (matrix/div (utils.bounds/->dimensions bbox) 2)
+  (let [{{:keys [cx cy rx ry]} :attrs} el
+        [cx cy rx ry] (mapv utils.length/unit->px [cx cy rx ry])
+        offset (utils.element/offset el)
+        [cx cy] (matrix/add [cx cy] offset)
         line-end-x (+ cx rx)
         line-end-y (- cy ry)]
     [:g ::edit-handles
@@ -128,3 +136,15 @@
 
      [utils.svg/label (utils.length/->fixed ry 2 false) {:x cx
                                                          :y (- cy (/ ry 2))}]]))
+
+(defmethod element.hierarchy/snapping-points :ellipse
+  [el]
+  (let [{{:keys [cx cy rx ry]} :attrs} el
+        rx (or rx ry)
+        ry (or ry rx)
+        [cx cy rx ry] (mapv utils.length/unit->px [cx cy rx ry])]
+    (mapv #(with-meta % {:label [::ellipe-edge "ellipse edge"]})
+          [[(- cx rx) cy]
+           [(+ cx rx) cy]
+           [cx (- cy ry)]
+           [cx (+ cy ry)]])))

--- a/src/renderer/element/impl/shape/ellipse.cljs
+++ b/src/renderer/element/impl/shape/ellipse.cljs
@@ -7,6 +7,7 @@
    [renderer.attribute.hierarchy :as attribute.hierarchy]
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.hierarchy :as hierarchy]
+   [renderer.tool.impl.element.core :as-alias element.core]
    [renderer.utils.bounds :as utils.bounds]
    [renderer.utils.element :as utils.element]
    [renderer.utils.length :as utils.length]
@@ -143,7 +144,7 @@
         rx (or rx ry)
         ry (or ry rx)
         [cx cy rx ry] (mapv utils.length/unit->px [cx cy rx ry])]
-    (mapv #(with-meta % {:label [::ellipe-edge "ellipse edge"]})
+    (mapv #(with-meta % {:label [::element.core/edge "edge"]})
           [[(- cx rx) cy]
            [(+ cx rx) cy]
            [cx (- cy ry)]

--- a/src/renderer/element/impl/shape/rect.cljs
+++ b/src/renderer/element/impl/shape/rect.cljs
@@ -34,15 +34,18 @@
 (defmethod element.hierarchy/scale :rect
   [el ratio pivot-point]
   (let [[x-ratio y-ratio] ratio
-        {{:keys [width height rx ry]} :attrs} el
-        [w h] (mapv utils.length/unit->px [width height])
+        {{:keys [width height rx ry stroke-width]} :attrs} el
+        [w h stroke-width] (->> [width height stroke-width]
+                                (mapv utils.length/unit->px))
         [offset-x offset-y] (utils.element/scale-offset ratio pivot-point)
-        offset [(+ offset-x (min 0 (* w x-ratio)))
-                (+ offset-y (min 0 (* h y-ratio)))]]
+        update-size (fn [ratio size]
+                      (- (* (+ size stroke-width) (abs ratio)) stroke-width))
+        offset [(+ offset-x (min 0 (* (+ w stroke-width) x-ratio)))
+                (+ offset-y (min 0 (* (+ h stroke-width) y-ratio)))]]
     (cond-> el
       :always
-      (-> (attribute.hierarchy/update-attr :width #(abs (* % x-ratio)))
-          (attribute.hierarchy/update-attr :height #(abs (* % y-ratio)))
+      (-> (attribute.hierarchy/update-attr :width (partial update-size x-ratio))
+          (attribute.hierarchy/update-attr :height (partial update-size y-ratio))
           (element.hierarchy/translate offset))
 
       rx
@@ -105,33 +108,36 @@
 
 (defmethod element.hierarchy/handles :rect
   [el]
-  (let [[min-x min-y max-x max-y] (:bbox el)
-        {{:keys [rx ry]} :attrs} el
-        [rx ry] (mapv utils.length/unit->px [rx ry])]
+  (let [{{:keys [x y width height rx ry]} :attrs} el
+        [x y width height rx ry] (->> [x y width height rx ry]
+                                      (mapv utils.length/unit->px))
+        offset (utils.element/offset el)
+        [x y] (matrix/add [x y] offset)
+        max-x (+ x width)]
     [{:type :handle
       :action :edit
       :parent (:id el)
-      :position [min-x min-y]
+      :position [x y]
       :id :position
       :label [::position-handle "position handle"]}
      {:type :handle
       :action :edit
       :parent (:id el)
-      :position [max-x max-y]
+      :position [max-x (+ y height)]
       :id :size
       :label [::size-handle "size handle"]}
      {:type :handle
       :action :edit
       :rounded true
       :parent (:id el)
-      :position [(- max-x rx) min-y]
+      :position [(- max-x rx) y]
       :id :rx
       :label [::rx-handle "x radius handle"]}
      {:type :handle
       :action :edit
       :rounded true
       :parent (:id el)
-      :position [max-x (+ min-y ry)]
+      :position [max-x (+ y ry)]
       :id :ry
       :label [::ry-handle "y radius handle"]}]))
 
@@ -162,3 +168,11 @@
       :always (conj "z")
       :always (->> (map #(cond-> % (number? %) utils.length/->fixed))
                    (string/join " ")))))
+
+(defmethod element.hierarchy/bbox :rect
+  [el]
+  (let [{{:keys [x y width height stroke-width]} :attrs} el
+        [x y width height stroke-width] (->> [x y width height stroke-width]
+                                             (mapv utils.length/unit->px))
+        padding (/ stroke-width 2)]
+    [(- x padding) (- y padding) (+ x width padding) (+ y height padding)]))

--- a/src/renderer/element/impl/shape/rect.cljs
+++ b/src/renderer/element/impl/shape/rect.cljs
@@ -45,7 +45,8 @@
     (cond-> el
       :always
       (-> (attribute.hierarchy/update-attr :width (partial update-size x-ratio))
-          (attribute.hierarchy/update-attr :height (partial update-size y-ratio))
+          (attribute.hierarchy/update-attr :height (partial update-size
+                                                            y-ratio))
           (element.hierarchy/translate offset))
 
       rx


### PR DESCRIPTION
Including the stroke width when calculating bounds is what most users would expect. It also helps snapping the element to its actual bounds. This is applied to rectangles, circles, and ellipses. Doing the same to more complex shapes (polygons, paths etc) is not that easy, because it depends on the stroke-linejoin attribute. Rotated or skewed elements might also be problematic in the future, but let's focus on improving the current behavior. Additional snapping points were added for the affected shapes, now that the bounding corners do not overlap with the shape edges.

https://github.com/user-attachments/assets/0a8a1b52-d0cf-4512-8c7d-d766dd1fee85