### PR TITLE
Move top level options to document attributes

### DIFF
--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -717,12 +717,9 @@
  {:close-panel "إغلاق اللوحة"}
 
  :renderer.app.core
- {:features "الميزات"
-  :grid "الشبكة"
+ {:help-view "عرض المساعدة"
   :help-bar "شريط المساعدة"
-  :debug-info "معلومات التصحيح"
-  :guides "الأدلة"
-  :rulers "المساطر"}
+  :debug-info "معلومات التصحيح"}
 
  :renderer.dialog.core
  {:dialog "مربع حوار"
@@ -748,7 +745,11 @@
   :gif "GIF"
   :reopen-last-closed "إعادة فتح آخر مغلق"
   :vector-formats "تنسيقات متجهية"
-  :rasterised-formats "تنسيقات نقطية"}
+  :rasterised-formats "تنسيقات نقطية"
+  :document-view "عرض المستند"
+  :grid "الشبكة"
+  :guides "الأدلة"
+  :rulers "المساطر"}
 
  :renderer.element.core
  {:cut "قص"
@@ -841,7 +842,7 @@
   :menubar-object "قائمة الكائن"
   :menubar-view "قائمة العرض"
   :menubar-help "قائمة المساعدة"
-  :help "مساعدة"}
+  :help-links "روابط المساعدة"}
 
  :renderer.panel.core
  {:panels "لوحات"

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -763,12 +763,9 @@
  {:close-panel "Panel schließen"}
 
  :renderer.app.core
- {:features "Funktionen"
-  :grid "Raster"
+ {:help-view "Hilfeansicht"
   :help-bar "Hilfeleiste"
-  :debug-info "Debug-Informationen"
-  :guides "Hilfslinien"
-  :rulers "Lineale"}
+  :debug-info "Debug-Informationen"}
 
  :renderer.dialog.core
  {:dialog "Dialog"
@@ -794,7 +791,11 @@
   :gif "GIF"
   :reopen-last-closed "Zuletzt geschlossenes erneut öffnen"
   :vector-formats "Vektorformate"
-  :rasterised-formats "Rasterformate"}
+  :rasterised-formats "Rasterformate"
+  :document-view "Dokumentansicht"
+  :grid "Raster"
+  :guides "Hilfslinien"
+  :rulers "Lineale"}
 
  :renderer.element.core
  {:cut "Ausschneiden"
@@ -887,7 +888,7 @@
   :menubar-object "Menü Objekt"
   :menubar-view "Menü Ansicht"
   :menubar-help "Menü Hilfe"
-  :help "Hilfe"}
+  :help-links "Hilfe-Links"}
 
  :renderer.panel.core
  {:panels "Panels"

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -767,12 +767,9 @@
  {:close-panel "Κλείσιμο πάνελ"}
 
  :renderer.app.core
- {:features "Χαρακτηριστικά"
-  :grid "Πλέγμα"
+ {:help-view "Προβολή βοήθειας"
   :help-bar "Μπάρα βοηθείας"
-  :debug-info "Πληροφορίες αποσφαλμάτωσης"
-  :guides "Οδηγοί"
-  :rulers "Χάρακες"}
+  :debug-info "Πληροφορίες αποσφαλμάτωσης"}
 
  :renderer.dialog.core
  {:dialog "Παράθυρο διαλόγου"
@@ -798,7 +795,11 @@
   :gif "GIF"
   :reopen-last-closed "Επαναφορά τελευταίου κλεισμένου"
   :vector-formats "Μορφές διανυσμάτων"
-  :rasterised-formats "Ραστεροποιημένες μορφές"}
+  :rasterised-formats "Ραστεροποιημένες μορφές"
+  :document-view "Προβολή εγγράφου"
+  :grid "Πλέγμα"
+  :guides "Οδηγοί"
+  :rulers "Χάρακες"}
 
  :renderer.element.core
  {:cut "Αποκοπή"
@@ -891,7 +892,7 @@
   :menubar-object "Μενού Αντικειμένου"
   :menubar-view "Μενού Προβολής"
   :menubar-help "Μενού Βοήθειας"
-  :help "Βοήθεια"}
+  :help-links "Σύνδεσμοι βοήθειας"}
 
  :renderer.panel.core
  {:panels "Πάνελ"

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -732,12 +732,9 @@
  {:close-panel "Close panel"}
 
  :renderer.app.core
- {:features "Features"
-  :grid "Grid"
+ {:help-view "Help view"
   :help-bar "Help bar"
-  :debug-info "Debug info"
-  :guides "Guides"
-  :rulers "Rulers"}
+  :debug-info "Debug info"}
 
  :renderer.dialog.core
  {:dialog "Dialog"
@@ -763,7 +760,11 @@
   :gif "GIF"
   :reopen-last-closed "Reopen last closed"
   :vector-formats "Vector formats"
-  :rasterised-formats "Rasterised formats"}
+  :rasterised-formats "Rasterised formats"
+  :document-view "Document view"
+  :grid "Grid"
+  :guides "Guides"
+  :rulers "Rulers"}
 
  :renderer.element.core
  {:cut "Cut"
@@ -856,7 +857,7 @@
   :menubar-object "Object menu"
   :menubar-view "View menu"
   :menubar-help "Help menu"
-  :help "Help"}
+  :help-links "Help links"}
 
  :renderer.panel.core
  {:panels "Panels"

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -750,12 +750,9 @@
  {:close-panel "Cerrar panel"}
 
  :renderer.app.core
- {:features "Características"
-  :grid "Cuadrícula"
+ {:help-view "Vista de ayuda"
   :help-bar "Barra de ayuda"
-  :debug-info "Información de depuración"
-  :guides "Guías"
-  :rulers "Reglas"}
+  :debug-info "Información de depuración"}
 
  :renderer.dialog.core
  {:dialog "Cuadro de diálogo"
@@ -781,7 +778,11 @@
   :gif "GIF"
   :reopen-last-closed "Reabrir último cerrado"
   :vector-formats "Formatos vectoriales"
-  :rasterised-formats "Formatos rasterizados"}
+  :rasterised-formats "Formatos rasterizados"
+  :document-view "Vista del documento"
+  :grid "Cuadrícula"
+  :guides "Guías"
+  :rulers "Reglas"}
 
  :renderer.element.core
  {:cut "Cortar"
@@ -874,7 +875,7 @@
   :menubar-object "Menú Objeto"
   :menubar-view "Menú Ver"
   :menubar-help "Menú Ayuda"
-  :help "Ayuda"}
+  :help-links "Enlaces de ayuda"}
 
  :renderer.panel.core
  {:panels "Paneles"

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -757,12 +757,9 @@
  {:close-panel "Fermer le panneau"}
 
  :renderer.app.core
- {:features "Fonctionnalités"
-  :grid "Grille"
+ {:help-view "Vue d'aide"
   :help-bar "Barre d'aide"
-  :debug-info "Informations de débogage"
-  :guides "Guides"
-  :rulers "Règles"}
+  :debug-info "Informations de débogage"}
 
  :renderer.dialog.core
  {:dialog "Boîte de dialogue"
@@ -788,7 +785,11 @@
   :gif "GIF"
   :reopen-last-closed "Rouvrir le dernier fermé"
   :vector-formats "Formats vectoriels"
-  :rasterised-formats "Formats matriciels"}
+  :rasterised-formats "Formats matriciels"
+  :document-view "Vue du document"
+  :grid "Grille"
+  :guides "Guides"
+  :rulers "Règles"}
 
  :renderer.element.core
  {:cut "Couper"
@@ -881,7 +882,7 @@
   :menubar-object "Menu Objet"
   :menubar-view "Menu Affichage"
   :menubar-help "Menu Aide"
-  :help "Aide"}
+  :help-links "Liens d'aide"}
 
  :renderer.panel.core
  {:panels "Panneaux"

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -760,12 +760,9 @@
  {:close-panel "Chiudi pannello"}
 
  :renderer.app.core
- {:features "Funzionalità"
-  :grid "Griglia"
+ {:help-view "Vista aiuto"
   :help-bar "Barra aiuto"
-  :debug-info "Info debug"
-  :guides "Guide"
-  :rulers "Righelli"}
+  :debug-info "Info debug"}
 
  :renderer.dialog.core
  {:dialog "Finestra di dialogo"
@@ -791,7 +788,11 @@
   :gif "GIF"
   :reopen-last-closed "Riapri ultimo chiuso"
   :vector-formats "Formati vettoriali"
-  :rasterised-formats "Formati rasterizzati"}
+  :rasterised-formats "Formati rasterizzati"
+  :document-view "Vista documento"
+  :grid "Griglia"
+  :guides "Guide"
+  :rulers "Righelli"}
 
  :renderer.element.core
  {:cut "Taglia"
@@ -884,7 +885,7 @@
   :menubar-object "Menu Oggetto"
   :menubar-view "Menu Visualizza"
   :menubar-help "Menu Aiuto"
-  :help "Aiuto"}
+  :help-links "Link di aiuto"}
 
  :renderer.panel.core
  {:panels "Pannelli"

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -702,12 +702,9 @@
  {:close-panel "パネルを閉じる"}
 
  :renderer.app.core
- {:features "機能"
-  :grid "グリッド"
+ {:help-view "ヘルプビュー"
   :help-bar "ヘルプバー"
-  :debug-info "デバッグ情報"
-  :guides "ガイド"
-  :rulers "ルーラー"}
+  :debug-info "デバッグ情報"}
 
  :renderer.dialog.core
  {:dialog "ダイアログ"
@@ -733,7 +730,11 @@
   :gif "GIF"
   :reopen-last-closed "最後に閉じたものを再度開く"
   :vector-formats "ベクター形式"
-  :rasterised-formats "ラスター形式"}
+  :rasterised-formats "ラスター形式"
+  :document-view "ドキュメントビュー"
+  :grid "グリッド"
+  :guides "ガイド"
+  :rulers "ルーラー"}
 
  :renderer.element.core
  {:cut "切り取り"
@@ -826,7 +827,7 @@
   :menubar-object "オブジェクトメニュー"
   :menubar-view "ビューメニュー"
   :menubar-help "ヘルプメニュー"
-  :help "ヘルプ"}
+  :help-links "ヘルプリンク"}
 
  :renderer.panel.core
  {:panels "パネル"

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -697,12 +697,9 @@
  {:close-panel "패널 닫기"}
 
  :renderer.app.core
- {:features "기능"
-  :grid "격자"
+ {:help-view "도움말 보기"
   :help-bar "도움말 바"
-  :debug-info "디버그 정보"
-  :guides "가이드"
-  :rulers "눈금자"}
+  :debug-info "디버그 정보"}
 
  :renderer.dialog.core
  {:dialog "대화 상자"
@@ -727,7 +724,11 @@
   :gif "GIF"
   :reopen-last-closed "마지막으로 닫은 항목 다시 열기"
   :vector-formats "벡터 형식"
-  :rasterised-formats "래스터 형식"}
+  :rasterised-formats "래스터 형식"
+  :document-view "문서 보기"
+  :grid "격자"
+  :guides "가이드"
+  :rulers "눈금자"}
 
  :renderer.element.core
  {:cut "잘라내기"
@@ -820,7 +821,7 @@
   :menubar-object "객체 메뉴"
   :menubar-view "보기 메뉴"
   :menubar-help "도움말 메뉴"
-  :help "도움말"}
+  :help-links "도움말 링크"}
 
  :renderer.panel.core
  {:panels "패널"

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -761,12 +761,9 @@
  {:close-panel "Paneel sluiten"}
 
  :renderer.app.core
- {:features "Functies"
-  :grid "Raster"
+ {:help-view "Helpweergave"
   :help-bar "Helpbalk"
-  :debug-info "Debug-informatie"
-  :guides "Hulplijnen"
-  :rulers "Linealen"}
+  :debug-info "Debug-informatie"}
 
  :renderer.dialog.core
  {:dialog "Dialoogvenster"
@@ -792,7 +789,11 @@
   :gif "GIF"
   :reopen-last-closed "Laatst gesloten opnieuw openen"
   :vector-formats "Vectorformaten"
-  :rasterised-formats "Rasterformaten"}
+  :rasterised-formats "Rasterformaten"
+  :document-view "Documentweergave"
+  :grid "Raster"
+  :guides "Hulplijnen"
+  :rulers "Linealen"}
 
  :renderer.element.core
  {:cut "Knippen"
@@ -885,7 +886,7 @@
   :menubar-object "Objectmenu"
   :menubar-view "Weergavemenu"
   :menubar-help "Helpmenu"
-  :help "Help"}
+  :help-links "Helplinks"}
 
  :renderer.panel.core
  {:panels "Panelen"

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -743,12 +743,9 @@
  {:close-panel "Fechar painel"}
 
  :renderer.app.core
- {:features "Funcionalidades"
-  :grid "Grelha"
+ {:help-view "Vista de ajuda"
   :help-bar "Barra de ajuda"
-  :debug-info "Informação de depuração"
-  :guides "Guias"
-  :rulers "Réguas"}
+  :debug-info "Informação de depuração"}
 
  :renderer.dialog.core
  {:dialog "Caixa de diálogo"
@@ -773,7 +770,11 @@
   :gif "GIF"
   :reopen-last-closed "Reabrir último fechado"
   :vector-formats "Formatos vetoriais"
-  :rasterised-formats "Formatos rasterizados"}
+  :rasterised-formats "Formatos rasterizados"
+  :document-view "Vista do documento"
+  :grid "Grelha"
+  :guides "Guias"
+  :rulers "Réguas"}
 
  :renderer.element.core
  {:cut "Cortar"
@@ -866,7 +867,7 @@
   :menubar-object "Menu Objeto"
   :menubar-view "Menu Visualização"
   :menubar-help "Menu Ajuda"
-  :help "Ajuda"}
+  :help-links "Links de ajuda"}
 
  :renderer.panel.core
  {:panels "Painéis"

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -744,12 +744,9 @@
  {:close-panel "Закрыть панель"}
 
  :renderer.app.core
- {:features "Функции"
-  :grid "Сетка"
+ {:help-view "Вид справки"
   :help-bar "Панель справки"
-  :debug-info "Отладочная информация"
-  :guides "Направляющие"
-  :rulers "Линейки"}
+  :debug-info "Отладочная информация"}
 
  :renderer.dialog.core
  {:dialog "Диалоговое окно"
@@ -775,7 +772,11 @@
   :gif "GIF"
   :reopen-last-closed "Открыть последний закрытый"
   :vector-formats "Векторные форматы"
-  :rasterised-formats "Растровые форматы"}
+  :rasterised-formats "Растровые форматы"
+  :document-view "Вид документа"
+  :grid "Сетка"
+  :guides "Направляющие"
+  :rulers "Линейки"}
 
  :renderer.element.core
  {:cut "Вырезать"
@@ -867,7 +868,7 @@
   :menubar-object "Меню Объект"
   :menubar-view "Меню Вид"
   :menubar-help "Меню Справка"
-  :help "Справка"}
+  :help-links "Ссылки справки"}
 
  :renderer.panel.core
  {:panels "Панели"

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -745,12 +745,9 @@
  {:close-panel "Stäng panel"}
 
  :renderer.app.core
- {:features "Funktioner"
-  :grid "Rutnät"
+ {:help-view "Hjälpvy"
   :help-bar "Hjälpfält"
-  :debug-info "Felsökningsinformation"
-  :guides "Stödlinjer"
-  :rulers "Linjaler"}
+  :debug-info "Felsökningsinformation"}
 
  :renderer.dialog.core
  {:dialog "Dialog"
@@ -776,7 +773,11 @@
   :gif "GIF"
   :reopen-last-closed "Öppna senast stängda igen"
   :vector-formats "Vektorformat"
-  :rasterised-formats "Rasterformat"}
+  :rasterised-formats "Rasterformat"
+  :document-view "Dokumentvy"
+  :grid "Rutnät"
+  :guides "Stödlinjer"
+  :rulers "Linjaler"}
 
  :renderer.element.core
  {:cut "Klipp ut"
@@ -869,7 +870,7 @@
   :menubar-object "Objektmeny"
   :menubar-view "Visningsmeny"
   :menubar-help "Hjälpmeny"
-  :help "Hjälp"}
+  :help-links "Hjälplänkar"}
 
  :renderer.panel.core
  {:panels "Paneler"

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -739,12 +739,9 @@
  {:close-panel "Paneli kapat"}
 
  :renderer.app.core
- {:features "Özellikler"
-  :grid "Izgara"
+ {:help-view "Yardım görünümü"
   :help-bar "Yardım çubuğu"
-  :debug-info "Hata ayıklama bilgisi"
-  :guides "Kılavuzlar"
-  :rulers "Cetveller"}
+  :debug-info "Hata ayıklama bilgisi"}
 
  :renderer.dialog.core
  {:dialog "İletişim kutusu"
@@ -770,7 +767,11 @@
   :gif "GIF"
   :reopen-last-closed "Son kapatılanı yeniden aç"
   :vector-formats "Vektör biçimleri"
-  :rasterised-formats "Raster biçimleri"}
+  :rasterised-formats "Raster biçimleri"
+  :document-view "Belge görünümü"
+  :grid "Izgara"
+  :guides "Kılavuzlar"
+  :rulers "Cetveller"}
 
  :renderer.element.core
  {:cut "Kes"
@@ -863,7 +864,7 @@
   :menubar-object "Nesne Menüsü"
   :menubar-view "Görünüm Menüsü"
   :menubar-help "Yardım Menüsü"
-  :help "Yardım"}
+  :help-links "Yardım bağlantıları"}
 
  :renderer.panel.core
  {:panels "Paneller"

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -658,12 +658,9 @@
  {:close-panel "关闭面板"}
 
  :renderer.app.core
- {:features "功能"
-  :grid "网格"
+ {:help-view "帮助视图"
   :help-bar "帮助栏"
-  :debug-info "调试信息"
-  :guides "参考线"
-  :rulers "标尺"}
+  :debug-info "调试信息"}
 
  :renderer.dialog.core
  {:dialog "对话框"
@@ -689,7 +686,11 @@
   :gif "GIF"
   :reopen-last-closed "重新打开上次关闭的"
   :vector-formats "矢量格式"
-  :rasterised-formats "光栅格式"}
+  :rasterised-formats "光栅格式"
+  :document-view "文档视图"
+  :grid "网格"
+  :guides "参考线"
+  :rulers "标尺"}
 
  :renderer.element.core
  {:cut "剪切"
@@ -782,7 +783,7 @@
   :menubar-object "对象菜单"
   :menubar-view "视图菜单"
   :menubar-help "帮助菜单"
-  :help "帮助"}
+  :help-links "帮助链接"}
 
  :renderer.panel.core
  {:panels "面板"

--- a/src/renderer/app/core.cljs
+++ b/src/renderer/app/core.cljs
@@ -8,41 +8,14 @@
    [renderer.utils.key :as utils.key]))
 
 (rf/dispatch [::action.events/register-action
-              {:id :view/toggle-grid
-               :label [::grid "Grid"]
-               :icon "grid"
-               :event [::app.events/toggle-grid]
-               :active [::app.subs/grid?]
-               :shortcuts [{:keyCode (utils.key/codes "PERIOD")
-                            :ctrlKey true}]}])
-
-(rf/dispatch [::action.events/register-action
-              {:id :view/toggle-rulers
-               :label [::rulers "Rulers"]
-               :icon "ruler-combined"
-               :event [::app.events/toggle-rulers]
-               :active [::app.subs/rulers?]
-               :shortcuts [{:keyCode (utils.key/codes "R")
-                            :ctrlKey true}]}])
-
-(rf/dispatch [::action.events/register-action
-              {:id :view/toggle-guides
-               :label [::guides "Guides"]
-               :icon "ruler-straight"
-               :event [::app.events/toggle-guides]
-               :active [::app.subs/guides?]
-               :shortcuts [{:keyCode (utils.key/codes "PERIOD")
-                            :shiftKey true}]}])
-
-(rf/dispatch [::action.events/register-action
-              {:id :view/toggle-help-bar
+              {:id :help-view/toggle-help-bar
                :label [::help-bar "Help bar"]
                :icon "info"
                :active [::app.subs/help-bar]
                :event [::app.events/toggle-help-bar]}])
 
 (rf/dispatch [::action.events/register-action
-              {:id :view/toggle-debug-info
+              {:id :help-view/toggle-debug-info
                :label [::debug-info "Debug info"]
                :icon "bug"
                :event [::app.events/toggle-debug-info]
@@ -52,11 +25,8 @@
                             :shiftKey true}]}])
 
 (rf/dispatch [::action.events/register-action-group
-              {:id :view/features
+              {:id :help-view
                :icon "toggles"
-               :label [::features "Features"]
-               :actions [:view/toggle-grid
-                         :view/toggle-rulers
-                         :view/toggle-guides
-                         :view/toggle-help-bar
-                         :view/toggle-debug-info]}])
+               :label [::help-view "Help view"]
+               :actions [:help-view/toggle-help-bar
+                         :help-view/toggle-debug-info]}])

--- a/src/renderer/app/db.cljs
+++ b/src/renderer/app/db.cljs
@@ -62,12 +62,6 @@
    [:double-click-delta {:default 300} [:and number? pos?]]
    [:state {:default :idle} State]
    [:cached-state {:optional true} State]
-   [:grid {:default false
-           :persist true} boolean?]
-   [:rulers {:default true
-             :persist true} boolean?]
-   [:guides {:default true
-             :persist true} boolean?]
    [:snap {:default {}
            :persist true} Snap]
    [:active-document {:optional true

--- a/src/renderer/app/events.cljs
+++ b/src/renderer/app/events.cljs
@@ -174,24 +174,6 @@
  (fn [db [_ visible]]
    (assoc db :backdrop visible)))
 
-(rf/reg-event-db
- ::toggle-grid
- [persist]
- (fn [db [_]]
-   (update db :grid not)))
-
-(rf/reg-event-db
- ::toggle-rulers
- [persist]
- (fn [db [_]]
-   (update db :rulers not)))
-
-(rf/reg-event-db
- ::toggle-guides
- [persist]
- (fn [db [_]]
-   (update db :guides not)))
-
 (rf/reg-event-fx
  ::load-system-fonts
  (fn [_ _]

--- a/src/renderer/app/home_view.cljs
+++ b/src/renderer/app/home_view.cljs
@@ -121,10 +121,8 @@
          [:h2.mb-3.mt-8.text-2xl
           (i18n.views/t [::help "Help"])]
 
-         (->> (conj [(action.views/deref-action :dialog/command-panel)]
-                    (->> :help
-                         (action.views/deref-action-group)
-                         :actions))
+         (->> (:actions (action.views/deref-action-group :help-links))
+              (conj [(action.views/deref-action :dialog/command-panel)])
               (flatten)
               (map command)
               (into [:div]))]]]]]]])

--- a/src/renderer/app/status_view.cljs
+++ b/src/renderer/app/status_view.cljs
@@ -197,8 +197,7 @@
           (interpose [:div.v-divider.hidden {:class "@5xl/toolbar:flex"}])
           (into [:<>]))
      [:div.grow.hidden.md:block]
-     (->> [:view/toggle-grid
-           :view/toggle-rulers]
+     (->> (:actions (action.views/deref-action-group :document/view))
           (keep views/tooltip-action-icon-button)
           (into [:<>]))
      [snap.views/root]

--- a/src/renderer/app/subs.cljs
+++ b/src/renderer/app/subs.cljs
@@ -80,18 +80,6 @@
  :-> :user-agent)
 
 (rf/reg-sub
- ::grid?
- :-> :grid)
-
-(rf/reg-sub
- ::rulers?
- :-> :rulers)
-
-(rf/reg-sub
- ::guides?
- :-> :guides)
-
-(rf/reg-sub
  ::loading?
  :-> :loading)
 

--- a/src/renderer/app/views.cljs
+++ b/src/renderer/app/views.cljs
@@ -189,7 +189,7 @@
 
 (defn frame-panel
   []
-  (let [rulers? @(rf/subscribe [::app.subs/rulers?])
+  (let [rulers? @(rf/subscribe [::document.subs/attr :rulers])
         md? @(rf/subscribe [::window.subs/md?])
         active? @(rf/subscribe [::tool.subs/active?
                                 ::tool.impl.misc.guide/guide])

--- a/src/renderer/document/core.cljs
+++ b/src/renderer/document/core.cljs
@@ -173,3 +173,38 @@
                          :document/close
                          :document/close-all
                          :document/close-saved]}])
+
+(rf/dispatch [::action.events/register-action
+              {:id :document-view/toggle-grid
+               :label [::grid "Grid"]
+               :icon "grid"
+               :event [::document.events/toggle-attr :grid]
+               :active [::document.subs/attr :grid]
+               :shortcuts [{:keyCode (utils.key/codes "PERIOD")
+                            :ctrlKey true}]}])
+
+(rf/dispatch [::action.events/register-action
+              {:id :document-view/toggle-rulers
+               :label [::rulers "Rulers"]
+               :icon "ruler-combined"
+               :event [::document.events/toggle-attr :rulers]
+               :active [::document.subs/attr :rulers]
+               :shortcuts [{:keyCode (utils.key/codes "R")
+                            :ctrlKey true}]}])
+
+(rf/dispatch [::action.events/register-action
+              {:id :document-view/toggle-guides
+               :label [::guides "Guides"]
+               :icon "ruler-straight"
+               :event [::document.events/toggle-attr :guides]
+               :active [::document.subs/attr :guides]
+               :shortcuts [{:keyCode (utils.key/codes "PERIOD")
+                            :shiftKey true}]}])
+
+(rf/dispatch [::action.events/register-action-group
+              {:id :document/view
+               :icon "toggles"
+               :label [::document-view "Document view"]
+               :actions [:document-view/toggle-grid
+                         :document-view/toggle-rulers
+                         :document-view/toggle-guides]}])

--- a/src/renderer/document/db.cljs
+++ b/src/renderer/document/db.cljs
@@ -15,7 +15,14 @@
 
 (def DocumentTitle [:string {:min 1}])
 
-(def DocumentAttrs [:map-of keyword? any?])
+(def DocumentAttrs
+  [:map
+   [:fill {:optional true} string?]
+   [:stroke {:optional true} string?]
+   [:stroke-width {:optional true} string?]
+   [:rulers {:optional true} boolean?]
+   [:guides {:optional true} boolean?]
+   [:grid {:optional true} boolean?]])
 
 (def Document
   [:map {:closed true}

--- a/src/renderer/document/db.cljs
+++ b/src/renderer/document/db.cljs
@@ -39,7 +39,9 @@
    [:centered {:optional true} boolean?]
    [:attrs {:default {:fill "lightgray"
                       :stroke "black"
-                      :stroke-width "1px"}} DocumentAttrs]
+                      :stroke-width "1px"
+                      :rulers true
+                      :guides true}} DocumentAttrs]
    [:preview-label {:optional true} string?]
    [:file-handle {:optional true} JS_Object]])
 

--- a/src/renderer/element/impl/container/canvas.cljs
+++ b/src/renderer/element/impl/container/canvas.cljs
@@ -70,7 +70,7 @@
         bbox @(rf/subscribe [::element.subs/bbox])
         active-tool @(rf/subscribe [::tool.subs/active])
         edit? @(rf/subscribe [::tool.subs/editing?])
-        grid? @(rf/subscribe [::app.subs/grid?])
+        grid? @(rf/subscribe [::document.subs/attr :grid])
         state @(rf/subscribe [::tool.subs/state])
         idle? @(rf/subscribe [::tool.subs/idle?])
         pointer-handler (partial input.impl.pointer/handler! el)

--- a/src/renderer/element/impl/custom/guide.cljs
+++ b/src/renderer/element/impl/custom/guide.cljs
@@ -1,7 +1,6 @@
 (ns renderer.element.impl.custom.guide
   (:require
    [re-frame.core :as rf]
-   [renderer.app.subs :as-alias app.subs]
    [renderer.attribute.hierarchy :as attribute.hierarchy]
    [renderer.attribute.views :as attribute.views]
    [renderer.document.subs :as-alias document.subs]
@@ -49,7 +48,7 @@
         hovered? @(rf/subscribe [::element.subs/hovered? (:id el)])
         pointer-handler (partial input.impl.pointer/handler! el)
         viewbox-bounds @(rf/subscribe [::frame.subs/viewbox-bounds])
-        guides? @(rf/subscribe [::app.subs/guides?])
+        guides? @(rf/subscribe [::document.subs/attr :guides])
         guides-locked? @(rf/subscribe [::document.subs/attr :guides-locked])
         attrs (default-attrs (:attrs el) viewbox-bounds)]
     (when guides?

--- a/src/renderer/menubar/core.cljs
+++ b/src/renderer/menubar/core.cljs
@@ -90,9 +90,9 @@
                        "https://github.com/repath-studio/repath-studio/issues/new/choose"]}])
 
 (rf/dispatch [::action.events/register-action-group
-              {:id :help
+              {:id :help-links
                :icon "help"
-               :label [::help "Help"]
+               :label [::help-links "Help links"]
                :actions [:help/website
                          :help/source-code
                          :help/license

--- a/src/renderer/menubar/views.cljs
+++ b/src/renderer/menubar/views.cljs
@@ -118,7 +118,6 @@
              (action.views/deref-action-group :theme/mode)
              (action.views/deref-action-group :a11y/filter)
              (action.views/deref-action-group :i18n/language)
-             (action.views/deref-action-group :view/features)
              {:type :separator
               :available [::window.subs/md?]}
              (action.views/deref-action-group :view/panels)
@@ -132,7 +131,8 @@
    :label [::help "Help"]
    :type :root
    :actions (->> [[:dialog/command-panel]
-                  (->> :help
+                  (:actions (action.views/deref-action-group :help-view))
+                  (->> :help-links
                        (action.views/deref-action-group)
                        :actions)
                   [:error/toggle-reporting]

--- a/src/renderer/tool/impl/misc/guide.cljs
+++ b/src/renderer/tool/impl/misc/guide.cljs
@@ -46,7 +46,7 @@
     (if
      orientation
       (-> db
-          (assoc :guides true)
+          (document.handlers/assoc-attr :guides true)
           (document.handlers/assoc-attr :guides-locked false)
           (tool.handlers/set-cursor (cursor orientation))
           (app.handlers/add-fx [::set-orientation orientation]))

--- a/test/app_test.cljs
+++ b/test/app_test.cljs
@@ -20,13 +20,6 @@
        (is @web?)
        (is (not @desktop?))))
 
-   (testing "toggling grid"
-     (let [grid? (rf/subscribe [::app.subs/grid?])]
-       (is (not @grid?))
-
-       (rf/dispatch [::app.events/toggle-grid])
-       (is @grid?)))
-
    (testing "toggling panel"
      (let [tree-visible (rf/subscribe [::panel.subs/visible? :tree])]
        (is @tree-visible)


### PR DESCRIPTION
Grid, rulers, and guides were moved under document attributes. The benefit is that each document can have its own persisted settings for those toggles. A guides toggle was added to the status bar, that now contains almost exclusively document specific options to improve consistency. We are also trying to gradually reduce the top level App db keys.