### PR TITLE
Refactor element hierarchy and improve permitted content checks

### DIFF
--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -140,7 +140,7 @@
  {:label "تعيين"
   :description "يوفر عنصر <set> في SVG طريقة لتعيين قيمة الخاصية لمدة محددة."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "مسار الحركة"
   :description "العنصر الفرعي SVG <mpath> الخاص بعنصر <animateMotion>
                 يتيح إمكانية الإشارة إلى عنصر <path> خارجي
@@ -227,7 +227,7 @@
   :description "ارسم خطوطاً حرة حساسة للضغط باستخدام perfect-freehand."
   :brush-point "نقطة الفرشاة"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "لوحة الرسم"
   :description "لوحة الرسم هي حاوية SVG الرئيسية التي تستضيف جميع
                 العناصر."

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -143,7 +143,7 @@
   :description "Das SVG-Element <set> stellt eine Methode bereit, den Wert eines
                 Attributs für eine angegebene Dauer festzulegen."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Bewegungspfad"
   :description "Das SVG-Unterelement <mpath> für das Element <animateMotion>
                 ermöglicht es, ein externes <path>-Element als Definition eines
@@ -236,7 +236,7 @@
                 perfect-freehand."
   :brush-point "Bürstenpunkt"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Leinwand"
   :description "Die Leinwand ist der Haupt-SVG-Container, der alle Elemente
                 beherbergt."

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -143,7 +143,7 @@
   :description "Το στοιχείο <set> του SVG παρέχει μια μέθοδο ορισμού της τιμής
                 ενός χαρακτηριστικού για μια καθορισμένη διάρκεια."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Διαδρομή κίνησης"
   :description "Το υποστοιχείο SVG <mpath> για το στοιχείο <animateMotion>
                 παρέχει τη δυνατότητα αναφοράς σε ένα εξωτερικό στοιχείο <path>
@@ -236,7 +236,7 @@
                 perfect-freehand."
   :brush-point "σημείο πινέλου"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Καμβάς"
   :description "Ο καμβάς είναι το κύριο πλαίσιο SVG που περιέχει όλα τα
                 στοιχεία."

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -142,7 +142,7 @@
   :description "The <set> SVG element provides a method of setting the value of
                  an attribute for a specified duration."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Motion Path"
   :description "The <mpath> SVG sub-element for the <animateMotion> element
                 provides the ability to reference an external <path> element as
@@ -229,7 +229,7 @@
   :description "Draw pressure-sensitive freehand lines using perfect-freehand."
   :brush-point "brush point"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Canvas"
   :description "The canvas is the main SVG container that hosts all elements."
   :fill-description "The fill attribute defines the background color of the main

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -143,7 +143,7 @@
   :description "El elemento SVG <set> proporciona un método para fijar el valor
                 de un atributo durante una duración especificada."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Trayectoria de movimiento"
   :description "El subelemento SVG <mpath> para el elemento <animateMotion>
                 permite referenciar un elemento <path> externo como definición
@@ -233,7 +233,7 @@
                 perfect-freehand."
   :brush-point "punto de pincel"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Lienzo"
   :description "El lienzo es el contenedor SVG principal que aloja todos los
                 elementos."

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -144,7 +144,7 @@
   :description "L'élément SVG <set> fournit une méthode pour définir la valeur
                 d'un attribut pendant une durée spécifiée."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Chemin de mouvement"
   :description "Le sous-élément SVG <mpath> pour l'élément <animateMotion>
                 permet de référencer un élément <path> externe comme définition
@@ -235,7 +235,7 @@
                 utilisant perfect-freehand."
   :brush-point "point de pinceau"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Canevas"
   :description "Le canevas est le conteneur SVG principal qui héberge tous les
                 éléments."

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -144,7 +144,7 @@
   :description "L'elemento SVG <set> fornisce un metodo per impostare il valore
                 di un attributo per una durata specificata."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Percorso di movimento"
   :description "Il sottoelemento SVG <mpath> per l'elemento <animateMotion>
                 fornisce la possibilità di fare riferimento a un elemento <path>
@@ -234,7 +234,7 @@
                 utilizzando perfect-freehand."
   :brush-point "punto pennello"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Tela"
   :description "La tela è il contenitore SVG principale che ospita tutti gli
                 elementi."

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -141,7 +141,7 @@
  {:label "設定"
   :description "SVGの<set>要素は、指定した期間、属性の値を設定する方法を提供します。"}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "モーションパス"
   :description "<animateMotion> 要素用の SVG サブ要素 <mpath> は、外部の <path>
                 要素をモーションパスの定義として参照する機能を提供します。"}
@@ -223,7 +223,7 @@
   :description "perfect-freehandを使用して、筆圧感応のフリーハンドラインを描画します。"
   :brush-point "ブラシポイント"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "キャンバス"
   :description "キャンバスは、すべての要素をホストするメインのSVGコンテナです。"
   :fill-description "塗りつぶし属性は、メインキャンバスの背景色を定義します。

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -141,7 +141,7 @@
  {:label "설정"
   :description "SVG <set> 요소는 지정된 기간 동안 속성의 값을 설정하는 방법을 제공합니다."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "모션 패스"
   :description "<animateMotion> 요소에 사용되는 SVG 서브요소 <mpath>는 외부의 <path>
                 요소를 모션 패스의 정의로서 참조할 수 있는 기능을 제공합니다."}
@@ -225,7 +225,7 @@
   :description "perfect-freehand를 사용하여 압력 감지 자유 곡선을 그립니다."
   :brush-point "브러시 포인트"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "캔버스"
   :description "캔버스는 모든 요소를 포함하는 주요 SVG 컨테이너입니다."
   :fill-description "채우기 속성은 메인 캔버스의 배경색을 정의합니다. 기본값은

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -144,7 +144,7 @@
   :description "Het SVG-element <set> biedt een manier om de waarde van een
                 attribuut voor een bepaalde duur in te stellen."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Bewegingspad"
   :description "Het SVG-subelement <mpath> voor het element <animateMotion>
                 stelt u in staat om naar een extern <path>-element te verwijzen
@@ -234,7 +234,7 @@
   :description "Teken drukkevoelige vrijhandlijnen met perfect-freehand."
   :brush-point "penseel punt"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Canvas"
   :description "Het canvas is de hoofd-SVG container die alle elementen bevat."
   :fill-description "Het vulattribuut definieert de achtergrondkleur van het

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -143,7 +143,7 @@
   :description "O elemento SVG <set> fornece um método para definir o valor de
                 um atributo durante uma duração especificada."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Percurso de movimento"
   :description "O subelemento SVG <mpath> para o elemento <animateMotion>
                 fornece a possibilidade de referenciar um elemento <path>
@@ -233,7 +233,7 @@
                 perfect-freehand."
   :brush-point "ponto de pincel"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Tela"
   :description "A tela é o contentor SVG principal que aloja todos os
                 elementos."

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -143,7 +143,7 @@
   :description "Элемент SVG <set> предоставляет способ установки значения
                 атрибута на определённый период времени."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Траектория движения"
   :description "SVG-подэлемент <mpath> для элемента <animateMotion>
                 предоставляет возможность ссылаться на внешний элемент <path>
@@ -229,7 +229,7 @@
                 perfect-freehand."
   :brush-point "точка кисти"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Холст"
   :description "Холст является основным контейнером SVG, который содержит все
                 элементы."

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -143,7 +143,7 @@
   :description "SVG-elementet <set> tillhandahåller ett sätt att sätta värdet på
                 ett attribut under en angiven tid."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Rörelsebana"
   :description "SVG-underelementet <mpath> för elementet <animateMotion> ger
                 möjlighet att referera ett externt <path>-element som
@@ -232,7 +232,7 @@
   :description "Rita tryckkänsliga frihandslinjer med perfect-freehand."
   :brush-point "penselpunkt"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Duk"
   :description "Duken är huvud-SVG behållaren som innehåller alla element."
   :fill-description "Fyllnadsattributet definierar bakgrundsfärgen för

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -143,7 +143,7 @@
   :description "<set> SVG öğesi, bir özniteliğin değerini belirli bir süre
                 boyunca ayarlamanın bir yöntemini sağlar."}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "Hareket yolu"
   :description "<animateMotion> öğesine ait SVG alt öğesi <mpath>, hareket
                 yolunun tanımı olarak dış bir <path> öğesine atıf yapabilme
@@ -233,7 +233,7 @@
                 çizgileri çizin."
   :brush-point "fırça noktası"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "Tuval"
   :description "Tuval, tüm öğeleri barındıran ana SVG kapsayıcısıdır."
   :fill-description "Dolgu özniteliği, ana tuvalin arka plan rengini tanımlar.

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -137,7 +137,7 @@
  {:label "设置"
   :description "SVG <set> 元素提供了一种方法，用于在指定时间内设置属性的值。"}
 
- :renderer.element.impl.mpath
+ :renderer.element.impl.descriptive.mpath
  {:label "运动路径"
   :description "<animateMotion> 元素的 SVG 子元素 <mpath>, 提供将外部 <path>
                 元素参考为运动路径定义的能力。"}
@@ -216,7 +216,7 @@
   :description "使用 perfect-freehand 绘制压力敏感的手绘线条。"
   :brush-point "画笔点"}
 
- :renderer.element.impl.container.canvas
+ :renderer.element.impl.custom.canvas
  {:label "画布"
   :description "画布是承载所有元素的主要 SVG 容器。"
   :fill-description "填充属性定义主画布的背景颜色。默认值取决于当前主题，这意味着

--- a/src/renderer/element/core.cljs
+++ b/src/renderer/element/core.cljs
@@ -288,21 +288,22 @@
                :label [::animate "Animate"]
                :icon "animation"
                :event [::element.events/animate :animate]
-               :enabled [::element.subs/some-selected?]}])
+               :enabled [::element.subs/some-allow-content? :animate]}])
 
 (rf/dispatch [::action.events/register-action
               {:id :animate/transform
                :label [::animate-transform "Animate Transform"]
                :icon "animation"
                :event [::element.events/animate :animateTransform]
-               :enabled [::element.subs/some-selected?]}])
+               :enabled [::element.subs/some-allow-content?
+                         :animateTransform]}])
 
 (rf/dispatch [::action.events/register-action
               {:id :animate/motion
                :label [::animate-motion "Animate Motion"]
                :icon "animation"
                :event [::element.events/animate :animateMotion]
-               :enabled [::element.subs/some-selected?]}])
+               :enabled [::element.subs/some-allow-content? :animateMotion]}])
 
 (rf/dispatch [::action.events/register-action
               {:id :path/simplify

--- a/src/renderer/element/handlers.cljs
+++ b/src/renderer/element/handlers.cljs
@@ -673,7 +673,7 @@
             (not= id parent-id)
             (not= (:parent el) parent-id)
             (not (contains? (descendant-ids db id) parent-id))
-            (utils.element/permitted-content? parent-el el))
+            (utils.element/permitted-content? parent-el (:tag el)))
        (-> (update-prop (:parent el) :children #(vec (remove #{id} %)))
            (update-prop parent-id :children utils.vec/add index id)
            (assoc-prop id :parent parent-id)
@@ -846,9 +846,15 @@
         is-translated (or (utils.element/svg? new-el)
                           (utils.element/root? new-el)
                           (:parent el))]
-    (if-not (element.db/valid? new-el)
+    (cond
+      (not (element.db/valid? new-el))
       (let [error (-> el element.db/explain m.error/humanize)]
         (throw (ex-info (str "Invalid element: " error) {:element new-el})))
+
+      (not (utils.element/permitted-content? parent-el (:tag new-el)))
+      (throw (js/Error. "Invalid parent"))
+
+      :else
       (cond-> db
         :always
         (assoc-in (path db id) new-el)

--- a/src/renderer/element/handlers.cljs
+++ b/src/renderer/element/handlers.cljs
@@ -851,7 +851,8 @@
       (let [error (-> el element.db/explain m.error/humanize)]
         (throw (ex-info (str "Invalid element: " error) {:element new-el})))
 
-      (not (utils.element/permitted-content? parent-el (:tag new-el)))
+      (and parent-el
+           (not (utils.element/permitted-content? parent-el (:tag new-el))))
       (throw (js/Error. "Invalid parent"))
 
       :else

--- a/src/renderer/element/hierarchy.cljs
+++ b/src/renderer/element/hierarchy.cljs
@@ -28,6 +28,7 @@
 (defmulti scale dispatch :hierarchy hierarchy/hierarchy)
 (defmulti handle-drag dispatch :hierarchy hierarchy/hierarchy)
 (defmulti handle-click dispatch :hierarchy hierarchy/hierarchy)
+(defmulti permitted-content dispatch :hierarchy hierarchy/hierarchy)
 (defmulti properties identity :hierarchy hierarchy/hierarchy)
 
 (defmethod render :default [_el])
@@ -43,6 +44,7 @@
 (defmethod scale :default [el _ratio _pivot-point] el)
 (defmethod handle-drag :default [el _offset _handle _lock?] el)
 (defmethod handle-click :default [el _handle] el)
+(defmethod permitted-content :default [_el])
 (defmethod properties :default [_tag])
 
 (hierarchy/derive! ::graphics ::renderable)

--- a/src/renderer/element/impl/animation/animate.cljs
+++ b/src/renderer/element/impl/animation/animate.cljs
@@ -11,7 +11,6 @@
   []
   {:icon "animation"
    :label [::label "Animate"]
-   :permitted-content #{::element.hierarchy/descriptive}
    :description [::description
                  "The SVG <animate> element provides a way to animate an
                   attribute of an element over time."]

--- a/src/renderer/element/impl/animation/animate_motion.cljs
+++ b/src/renderer/element/impl/animation/animate_motion.cljs
@@ -11,7 +11,6 @@
   []
   {:icon "animation"
    :label [::label "Animate Motion"]
-   :permitted-content #{::element.hierarchy/descriptive}
    :description [::description
                  "The SVG <animateMotion> element let define how an element
                   moves along a motion path."]})

--- a/src/renderer/element/impl/animation/animate_transform.cljs
+++ b/src/renderer/element/impl/animation/animate_transform.cljs
@@ -11,7 +11,6 @@
   []
   {:icon "animation"
    :label [::label "Animate Transform"]
-   :permitted-content #{::element.hierarchy/descriptive}
    :description [::description
                  "The <animateTransform> element animates a
                   transformation attribute on its target element, thereby

--- a/src/renderer/element/impl/animation/core.cljs
+++ b/src/renderer/element/impl/animation/core.cljs
@@ -10,9 +10,7 @@
    [renderer.element.subs :as-alias element.subs]
    [renderer.hierarchy :as hierarchy]))
 
-(hierarchy/derive!
- ::element.hierarchy/animation
- ::element.hierarchy/element)
+(hierarchy/derive! ::element.hierarchy/animation ::element.hierarchy/element)
 
 (defmethod element.hierarchy/render ::element.hierarchy/animation
   [el]

--- a/src/renderer/element/impl/animation/core.cljs
+++ b/src/renderer/element/impl/animation/core.cljs
@@ -22,3 +22,7 @@
      (for [el child-elements]
        ^{:key id}
        [element.hierarchy/render el])]))
+
+(defmethod element.hierarchy/permitted-content ::element.hierarchy/animation
+  [_el]
+  #{::element.hierarchy/descriptive})

--- a/src/renderer/element/impl/animation/set.cljs
+++ b/src/renderer/element/impl/animation/set.cljs
@@ -11,7 +11,6 @@
   []
   {:icon "animation"
    :label [::label "Set"]
-   :permitted-content #{::element.hierarchy/descriptive}
    :description [::description
                  "The <set> SVG element provides a method of setting the value
                   of an attribute for a specified duration."]})

--- a/src/renderer/element/impl/container/core.cljs
+++ b/src/renderer/element/impl/container/core.cljs
@@ -3,7 +3,6 @@
   (:require
    [re-frame.core :as rf]
    [renderer.element.hierarchy :as element.hierarchy]
-   [renderer.element.impl.container.canvas]
    [renderer.element.impl.container.group]
    [renderer.element.impl.container.svg]
    [renderer.element.subs :as-alias element.subs]
@@ -38,3 +37,12 @@
                    (into {}))]
     (into [tag attrs (when title [:title title])]
           (map element.hierarchy/render-to-string child-elements))))
+
+(defmethod element.hierarchy/permitted-content ::element.hierarchy/container
+  [_el]
+  #{::element.hierarchy/animation
+    ::element.hierarchy/container
+    ::element.hierarchy/custom
+    ::element.hierarchy/descriptive
+    ::element.hierarchy/shape
+    ::element.hierarchy/gradient})

--- a/src/renderer/element/impl/container/group.cljs
+++ b/src/renderer/element/impl/container/group.cljs
@@ -17,12 +17,6 @@
   []
   {:icon "group"
    :label [::label "Group"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/container
-                        ::element.hierarchy/custom
-                        ::element.hierarchy/descriptive
-                        ::element.hierarchy/shape
-                        ::element.hierarchy/gradient}
    :description [::description "The <g> SVG element is a container used to group
                                 other SVG elements."]
    :attrs []})

--- a/src/renderer/element/impl/container/svg.cljs
+++ b/src/renderer/element/impl/container/svg.cljs
@@ -21,12 +21,6 @@
   {:icon "svg"
    :top-level true
    :label label
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/container
-                        ::element.hierarchy/custom
-                        ::element.hierarchy/descriptive
-                        ::element.hierarchy/shape
-                        ::element.hierarchy/gradient}
    :description [::description
                  "The svg element is a container that defines a new
                   coordinate system and viewport. It is used as the outermost

--- a/src/renderer/element/impl/core.cljs
+++ b/src/renderer/element/impl/core.cljs
@@ -4,7 +4,7 @@
    [renderer.element.impl.box]
    [renderer.element.impl.container.core]
    [renderer.element.impl.custom.core]
-   [renderer.element.impl.mpath]
+   [renderer.element.impl.descriptive.core]
    [renderer.element.impl.renderable]
    [renderer.element.impl.shape.core]
    [renderer.element.impl.text]))

--- a/src/renderer/element/impl/custom/blob.cljs
+++ b/src/renderer/element/impl/custom/blob.cljs
@@ -10,7 +10,6 @@
    [renderer.attribute.views :as attribute.views]
    [renderer.element.events :as-alias element.events]
    [renderer.element.hierarchy :as element.hierarchy]
-   [renderer.element.subs :as-alias element.subs]
    [renderer.hierarchy :as hierarchy]
    [renderer.i18n.views :as i18n.views]
    [renderer.input.impl.pointer :as input.impl.pointer]
@@ -108,19 +107,17 @@
 
 (defmethod element.hierarchy/render :blob
   [el]
-  (let [{:keys [attrs children]} el
-        child-elements @(rf/subscribe [::element.subs/filter-visible children])
-        pointer-handler (partial input.impl.pointer/handler! el)]
+  (let [pointer-handler (partial input.impl.pointer/handler! el)]
     [:path (merge {:d (element.hierarchy/path el)
                    :on-pointer-up pointer-handler
                    :on-pointer-down pointer-handler
                    :on-pointer-move pointer-handler}
-                  (select-keys attrs [:stroke
-                                      :fill
-                                      :stroke-width
-                                      :id
-                                      :class
-                                      :opacity])) child-elements]))
+                  (select-keys (:attrs el) [:stroke
+                                            :fill
+                                            :stroke-width
+                                            :id
+                                            :class
+                                            :opacity]))]))
 
 (defmethod element.hierarchy/translate :blob
   [el [x y]]

--- a/src/renderer/element/impl/custom/canvas.cljs
+++ b/src/renderer/element/impl/custom/canvas.cljs
@@ -1,4 +1,4 @@
-(ns renderer.element.impl.container.canvas
+(ns renderer.element.impl.custom.canvas
   "The main SVG element that hosts all pages."
   (:require
    [re-frame.core :as rf]
@@ -28,12 +28,6 @@
 (defmethod element.hierarchy/properties :canvas
   []
   {:label [::label "Canvas"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/container
-                        ::element.hierarchy/custom
-                        ::element.hierarchy/descriptive
-                        ::element.hierarchy/shape
-                        ::element.hierarchy/gradient}
    :description [::description "The canvas is the main SVG container that hosts
                                 all elements."]
    :attrs [:fill]})
@@ -128,3 +122,11 @@
     (into [:svg attrs]
           (map element.hierarchy/render-to-string)
           child-elements)))
+
+(defmethod element.hierarchy/permitted-content :canvas
+  [_el]
+  #{::element.hierarchy/container
+    ::element.hierarchy/custom
+    ::element.hierarchy/descriptive
+    ::element.hierarchy/shape
+    ::element.hierarchy/gradient})

--- a/src/renderer/element/impl/custom/core.cljs
+++ b/src/renderer/element/impl/custom/core.cljs
@@ -3,6 +3,7 @@
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.element.impl.custom.blob]
    [renderer.element.impl.custom.brush]
+   [renderer.element.impl.custom.canvas]
    [renderer.element.impl.custom.guide]
    [renderer.hierarchy :as hierarchy]))
 

--- a/src/renderer/element/impl/descriptive/core.cljs
+++ b/src/renderer/element/impl/descriptive/core.cljs
@@ -1,0 +1,8 @@
+(ns renderer.element.impl.descriptive.core
+  (:require
+   [renderer.element.hierarchy :as element.hierarchy]
+   [renderer.element.impl.descriptive.mpath]))
+
+(defmethod element.hierarchy/permitted-content :element.hierarchy/descriptive
+  [_el]
+  #{::element.hierarchy/descriptive})

--- a/src/renderer/element/impl/descriptive/mpath.cljs
+++ b/src/renderer/element/impl/descriptive/mpath.cljs
@@ -1,4 +1,4 @@
-(ns renderer.element.impl.mpath
+(ns renderer.element.impl.descriptive.mpath
   "https://svgwg.org/specs/animations/#MPathElement
    https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/mpath"
   (:require
@@ -11,7 +11,6 @@
   []
   {:icon "bezier-curve"
    :label [::label "Motion Path"]
-   :permitted-content #{::element.hierarchy/descriptive}
    :description [::description
                  "The <mpath> SVG sub-element for the <animateMotion> element
                   provides the ability to reference an external <path> element

--- a/src/renderer/element/impl/shape/circle.cljs
+++ b/src/renderer/element/impl/shape/circle.cljs
@@ -20,8 +20,6 @@
   []
   {:icon "circle"
    :label [::label "Circle"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/descriptive}
    :description [::description
                  "The <circle> SVG element is an SVG basic shape, used to
                   draw circles based on a center point and a radius."]

--- a/src/renderer/element/impl/shape/core.cljs
+++ b/src/renderer/element/impl/shape/core.cljs
@@ -27,3 +27,8 @@
                    (into {}))]
     (into [tag attrs (when title [:title title]) content]
           (map element.hierarchy/render-to-string child-elements))))
+
+(defmethod element.hierarchy/permitted-content ::element.hierarchy/shape
+  [_el]
+  #{::element.hierarchy/animation
+    ::element.hierarchy/descriptive})

--- a/src/renderer/element/impl/shape/ellipse.cljs
+++ b/src/renderer/element/impl/shape/ellipse.cljs
@@ -20,8 +20,6 @@
   []
   {:icon "ellipse"
    :label [::label "Ellipse"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/descriptive}
    :description [::description
                  "The <ellipse> element is an SVG basic shape, used to create
                   ellipses based on a center coordinate, and both their x and

--- a/src/renderer/element/impl/shape/image.cljs
+++ b/src/renderer/element/impl/shape/image.cljs
@@ -12,8 +12,6 @@
   []
   {:icon "image"
    :label [::label "Image"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/descriptive}
    :description [::description
                  "The <image> SVG element includes images inside SVG documents.
                   It can display raster image files or other SVG files."]

--- a/src/renderer/element/impl/shape/line.cljs
+++ b/src/renderer/element/impl/shape/line.cljs
@@ -18,8 +18,6 @@
   []
   {:icon "line"
    :label [::label "Line"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/descriptive}
    :description [::description
                  "The <line> element is an SVG basic shape used to create a line
                   connecting two points."]

--- a/src/renderer/element/impl/shape/path.cljs
+++ b/src/renderer/element/impl/shape/path.cljs
@@ -22,8 +22,6 @@
   []
   {:icon "bezier-curve"
    :label [::label "Path"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/descriptive}
    :description [::description
                  "The <path> SVG element is the generic element to define a
                   shape. All the basic shapes can be created with a path

--- a/src/renderer/element/impl/shape/polygon.cljs
+++ b/src/renderer/element/impl/shape/polygon.cljs
@@ -11,8 +11,6 @@
   []
   {:icon "polygon"
    :label [::label "Polygon"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/descriptive}
    :description [::description
                  "The <polygon> SVG element defines a closed shape consisting
                   of a set of connected straight line segments. The last

--- a/src/renderer/element/impl/shape/polyline.cljs
+++ b/src/renderer/element/impl/shape/polyline.cljs
@@ -11,8 +11,6 @@
   []
   {:icon "polyline-tool"
    :label [::label "Polyline"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/descriptive}
    :description [::description
                  "The <polyline> SVG element is an SVG basic shape that
                   creates straight lines connecting several points. Typically

--- a/src/renderer/element/impl/shape/rect.cljs
+++ b/src/renderer/element/impl/shape/rect.cljs
@@ -20,8 +20,6 @@
   []
   {:icon "rectangle"
    :label [::label "Rectangle"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/descriptive}
    :description [::description
                  "The <rect> element is a basic SVG shape that draws
                   rectangles, defined by their position, width, and height.

--- a/src/renderer/element/impl/text.cljs
+++ b/src/renderer/element/impl/text.cljs
@@ -28,8 +28,6 @@
   []
   {:icon "text"
    :label [::label "Text"]
-   :permitted-content #{::element.hierarchy/animation
-                        ::element.hierarchy/descriptive}
    :description [::description
                  "The SVG <text> element draws a graphics element consisting
                   of text. It's possible to apply a gradient, pattern,

--- a/src/renderer/element/subs.cljs
+++ b/src/renderer/element/subs.cljs
@@ -79,6 +79,14 @@
  :-> (comp boolean seq))
 
 (rf/reg-sub
+ ::some-allow-content?
+ :<- [::selected]
+ (fn [selected-elements [_ tag]]
+   (->> selected-elements
+        (some #(utils.element/permitted-content? % tag))
+        (boolean))))
+
+(rf/reg-sub
  ::every-selected-locked?
  :<- [::selected]
  :-> (partial every? :locked))

--- a/src/renderer/utils/element.cljs
+++ b/src/renderer/utils/element.cljs
@@ -319,10 +319,10 @@
                    (string/upper-case)
                    (string/includes? "M"))))
 
-(m/=> permitted-content? [:-> Element Element boolean?])
+(m/=> permitted-content? [:-> Element ElementTag boolean?])
 (defn permitted-content?
-  [parent child]
-  (let [permitted-content (:permitted-content (properties parent))]
+  [parent tag]
+  (let [permitted-content (element.hierarchy/permitted-content parent)]
     (->> permitted-content
-         (some (partial isa? @hierarchy/hierarchy (:tag child)))
+         (some (partial isa? @hierarchy/hierarchy tag))
          (boolean))))


### PR DESCRIPTION
- Convert `permitted-`content to a dedicated multimethod to avoid duplication.
- Create a `descriptive` directory under elements and move `mpath` into it.
- Move `canvas` to custom elements
- Enhance permitted content filtering on create and on animate