### PR TITLE
Introduce "add motion path" action

### DIFF
--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -119,7 +119,8 @@
   :trace-image "تتبع الصورة"
   :toggle-handle-selection "Toggle handle selection"
   :combine "دمج"
-  :break-apart "فصل"}
+  :break-apart "فصل"
+  :add-motion-path "إضافة مسار الحركة"}
 
  :renderer.element.impl.animation.animate
  {:label "تحريك"

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -119,7 +119,8 @@
   :trace-image "Bild nachzeichnen"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Kombinieren"
-  :break-apart "Trennen"}
+  :break-apart "Trennen"
+  :add-motion-path "Bewegungspfad hinzufügen"}
 
  :renderer.element.impl.animation.animate
  {:label "Animieren"

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -119,7 +119,8 @@
   :trace-image "Ανίχνευση εικόνας"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Συνδυασμός"
-  :break-apart "Διάσπαση"}
+  :break-apart "Διάσπαση"
+  :add-motion-path "Προσθήκη διαδρομής κίνησης"}
 
  :renderer.element.impl.animation.animate
  {:label "Κίνηση"

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -119,7 +119,8 @@
   :trace-image "Trace image"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Combine"
-  :break-apart "Break apart"}
+  :break-apart "Break apart"
+  :add-motion-path "Add motion path"}
 
  :renderer.element.impl.animation.animate
  {:label "Animate"

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -119,7 +119,8 @@
   :trace-image "Vectorizar imagen"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Combinar"
-  :break-apart "Separar"}
+  :break-apart "Separar"
+  :add-motion-path "Añadir trayectoria de movimiento"}
 
  :renderer.element.impl.animation.animate
  {:label "Animar"

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -120,7 +120,8 @@
   :trace-image "Vectoriser l'image"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Combiner"
-  :break-apart "Séparer"}
+  :break-apart "Séparer"
+  :add-motion-path "Ajouter un chemin de mouvement"}
 
  :renderer.element.impl.animation.animate
  {:label "Animer"

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -120,7 +120,8 @@
   :trace-image "Traccia immagine"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Combina"
-  :break-apart "Separa"}
+  :break-apart "Separa"
+  :add-motion-path "Aggiungi percorso di movimento"}
 
  :renderer.element.impl.animation.animate
  {:label "Anima"

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -119,7 +119,8 @@
   :trace-image "画像をトレース"
   :toggle-handle-selection "Toggle handle selection"
   :combine "複合"
-  :break-apart "分割"}
+  :break-apart "分割"
+  :add-motion-path "モーションパスを追加"}
 
  :renderer.element.impl.animation.animate
  {:label "アニメーション"

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -119,7 +119,8 @@
   :trace-image "이미지 추적"
   :toggle-handle-selection "Toggle handle selection"
   :combine "결합"
-  :break-apart "분리"}
+  :break-apart "분리"
+  :add-motion-path "모션 패스 추가"}
 
  :renderer.element.impl.animation.animate
  {:label "애니메이션"

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -119,7 +119,8 @@
   :trace-image "Afbeelding traceren"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Combineren"
-  :break-apart "Opsplitsen"}
+  :break-apart "Opsplitsen"
+  :add-motion-path "Bewegingspad toevoegen"}
 
  :renderer.element.impl.animation.animate
  {:label "Animeren"

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -119,7 +119,8 @@
   :trace-image "Vetorizar imagem"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Combinar"
-  :break-apart "Separar"}
+  :break-apart "Separar"
+  :add-motion-path "Adicionar percurso de movimento"}
 
  :renderer.element.impl.animation.animate
  {:label "Animar"

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -120,7 +120,8 @@
   :trace-image "Трассировать изображение"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Совместить"
-  :break-apart "Разбить"}
+  :break-apart "Разбить"
+  :add-motion-path "Добавить траекторию движения"}
 
  :renderer.element.impl.animation.animate
  {:label "Анимировать"

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -119,7 +119,8 @@
   :trace-image "Spåra bild"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Kombinera"
-  :break-apart "Dela upp"}
+  :break-apart "Dela upp"
+  :add-motion-path "Lägg till rörelsebana"}
 
  :renderer.element.impl.animation.animate
  {:label "Animera"

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -119,7 +119,8 @@
   :trace-image "Resim izini sür"
   :toggle-handle-selection "Toggle handle selection"
   :combine "Kombine"
-  :break-apart "Parçalara Ayır"}
+  :break-apart "Parçalara Ayır"
+  :add-motion-path "Hareket yolu ekle"}
 
  :renderer.element.impl.animation.animate
  {:label "Animasyon"

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -118,7 +118,8 @@
   :trace-image "描摹图像"
   :toggle-handle-selection "Toggle handle selection"
   :combine "组合"
-  :break-apart "拆分"}
+  :break-apart "拆分"
+  :add-motion-path "添加运动路径"}
 
  :renderer.element.impl.animation.animate
  {:label "动画"

--- a/src/renderer/element/core.cljs
+++ b/src/renderer/element/core.cljs
@@ -306,6 +306,13 @@
                :enabled [::element.subs/some-allow-content? :animateMotion]}])
 
 (rf/dispatch [::action.events/register-action
+              {:id :animate/add-mpath
+               :label [::add-mpath "Add motion path"]
+               :icon "bezier-curve"
+               :event [::element.events/add-mpath]
+               :enabled [::element.subs/some-selected-tag? :animateMotion]}])
+
+(rf/dispatch [::action.events/register-action
               {:id :path/simplify
                :label [::path-simplify "Simplify"]
                :icon "bezier-curve"
@@ -426,7 +433,8 @@
                :enabled [::element.subs/some-selected?]
                :actions [:animate/animate
                          :animate/transform
-                         :animate/motion]}])
+                         :animate/motion
+                         :animate/add-mpath]}])
 
 (rf/dispatch [::action.events/register-action-group
               {:id :object/entity

--- a/src/renderer/element/core.cljs
+++ b/src/renderer/element/core.cljs
@@ -307,7 +307,7 @@
 
 (rf/dispatch [::action.events/register-action
               {:id :animate/add-mpath
-               :label [::add-mpath "Add motion path"]
+               :label [::element.events/add-motion-path]
                :icon "bezier-curve"
                :event [::element.events/add-mpath]
                :enabled [::element.subs/some-selected-tag? :animateMotion]}])

--- a/src/renderer/element/events.cljs
+++ b/src/renderer/element/events.cljs
@@ -277,6 +277,19 @@
    (element.handlers/animate db tag attrs)))
 
 (rf/reg-event-db
+ ::add-mpath
+ [(finalize [::add-mpath "Add motion path"])]
+ (fn [db _]
+   (let [parent-els (element.handlers/filter-selected-by-tag db :animateMotion)]
+     (reduce (fn [db parent]
+               (element.handlers/create db {:type :element
+                                            :tag :mpath
+                                            :selected true
+                                            :parent (:id parent)}))
+             (element.handlers/deselect db)
+             parent-els))))
+
+(rf/reg-event-db
  ::set-parent
  [(finalize [::set-parent "Set parent"])]
  (fn [db [_ id parent-id]]

--- a/src/renderer/element/events.cljs
+++ b/src/renderer/element/events.cljs
@@ -278,7 +278,7 @@
 
 (rf/reg-event-db
  ::add-mpath
- [(finalize [::add-mpath "Add motion path"])]
+ [(finalize [::add-motion-path "Add motion path"])]
  (fn [db _]
    (let [parent-els (element.handlers/filter-selected-by-tag db :animateMotion)]
      (reduce (fn [db parent]

--- a/src/renderer/element/impl/container/core.cljs
+++ b/src/renderer/element/impl/container/core.cljs
@@ -6,8 +6,7 @@
    [renderer.element.impl.container.group]
    [renderer.element.impl.container.svg]
    [renderer.element.subs :as-alias element.subs]
-   [renderer.hierarchy :as hierarchy]
-   [renderer.utils.element :as utils.element]))
+   [renderer.hierarchy :as hierarchy]))
 
 (hierarchy/derive! ::element.hierarchy/container ::element.hierarchy/renderable)
 
@@ -27,16 +26,6 @@
     [tag attrs (for [el child-elements]
                  ^{:key id}
                  [element.hierarchy/render el])]))
-
-(defmethod element.hierarchy/render-to-string ::element.hierarchy/container
-  [el]
-  (let [{:keys [tag attrs title children]} el
-        child-elements @(rf/subscribe [::element.subs/filter-visible children])
-        attrs (->> (utils.element/style->map attrs)
-                   (remove #(empty? (str (second %))))
-                   (into {}))]
-    (into [tag attrs (when title [:title title])]
-          (map element.hierarchy/render-to-string child-elements))))
 
 (defmethod element.hierarchy/permitted-content ::element.hierarchy/container
   [_el]

--- a/src/renderer/element/impl/container/core.cljs
+++ b/src/renderer/element/impl/container/core.cljs
@@ -1,11 +1,9 @@
 (ns renderer.element.impl.container.core
   "https://www.w3.org/TR/SVG/struct.html#TermContainerElement"
   (:require
-   [re-frame.core :as rf]
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.element.impl.container.group]
    [renderer.element.impl.container.svg]
-   [renderer.element.subs :as-alias element.subs]
    [renderer.hierarchy :as hierarchy]))
 
 (hierarchy/derive! ::element.hierarchy/container ::element.hierarchy/renderable)
@@ -18,14 +16,6 @@
 (hierarchy/derive! :pattern ::element.hierarchy/container)
 (hierarchy/derive! :switch ::element.hierarchy/container)
 (hierarchy/derive! :symbol ::element.hierarchy/container)
-
-(defmethod element.hierarchy/render ::element.hierarchy/container
-  [el]
-  (let [{:keys [children tag attrs id]} el
-        child-elements @(rf/subscribe [::element.subs/filter-visible children])]
-    [tag attrs (for [el child-elements]
-                 ^{:key id}
-                 [element.hierarchy/render el])]))
 
 (defmethod element.hierarchy/permitted-content ::element.hierarchy/container
   [_el]

--- a/src/renderer/element/impl/renderable.cljs
+++ b/src/renderer/element/impl/renderable.cljs
@@ -4,18 +4,18 @@
    [re-frame.core :as rf]
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.element.subs :as-alias element.subs]
-   [renderer.element.views :as element.views]
    [renderer.hierarchy :as hierarchy]
-   [renderer.tool.subs :as-alias tool.subs]
    [renderer.utils.element :as utils.element]))
 
 (hierarchy/derive! ::element.hierarchy/renderable ::element.hierarchy/element)
 
 (defmethod element.hierarchy/render ::element.hierarchy/renderable
   [el]
-  (let [child-els @(rf/subscribe [::element.subs/filter-visible (:children el)])
-        idle? @(rf/subscribe [::tool.subs/idle?])]
-    [element.views/render-to-dom el child-els idle?]))
+  (let [{:keys [children tag attrs id]} el
+        child-elements @(rf/subscribe [::element.subs/filter-visible children])]
+    [tag attrs (for [el child-elements]
+                 ^{:key id}
+                 [element.hierarchy/render el])]))
 
 (defmethod element.hierarchy/render-to-string ::element.hierarchy/renderable
   [el]

--- a/src/renderer/element/impl/renderable.cljs
+++ b/src/renderer/element/impl/renderable.cljs
@@ -17,6 +17,16 @@
         idle? @(rf/subscribe [::tool.subs/idle?])]
     [element.views/render-to-dom el child-els idle?]))
 
+(defmethod element.hierarchy/render-to-string ::element.hierarchy/renderable
+  [el]
+  (let [{:keys [tag attrs title children content]} el
+        child-elements @(rf/subscribe [::element.subs/filter-visible children])
+        attrs (->> (utils.element/style->map attrs)
+                   (remove #(empty? (str (second %))))
+                   (into {}))]
+    (into [tag attrs (when title [:title title]) content]
+          (map element.hierarchy/render-to-string child-elements))))
+
 (defmethod element.hierarchy/bbox ::element.hierarchy/renderable
   [el]
   (:bbox (utils.element/get-computed-styles el)))

--- a/src/renderer/element/impl/shape/core.cljs
+++ b/src/renderer/element/impl/shape/core.cljs
@@ -1,6 +1,7 @@
 (ns renderer.element.impl.shape.core
   "https://www.w3.org/TR/SVG/shapes.html#TermShapeElement"
   (:require
+   [re-frame.core :as rf]
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.element.impl.shape.circle]
    [renderer.element.impl.shape.ellipse]
@@ -11,7 +12,10 @@
    [renderer.element.impl.shape.polygon]
    [renderer.element.impl.shape.polyline]
    [renderer.element.impl.shape.rect]
-   [renderer.hierarchy :as hierarchy]))
+   [renderer.element.subs :as-alias element.subs]
+   [renderer.element.views :as element.views]
+   [renderer.hierarchy :as hierarchy]
+   [renderer.tool.subs :as-alias tool.subs]))
 
 (hierarchy/derive! ::element.hierarchy/shape ::element.hierarchy/graphics)
 
@@ -19,3 +23,9 @@
   [_el]
   #{::element.hierarchy/animation
     ::element.hierarchy/descriptive})
+
+(defmethod element.hierarchy/render ::element.hierarchy/shape
+  [el]
+  (let [child-els @(rf/subscribe [::element.subs/filter-visible (:children el)])
+        idle? @(rf/subscribe [::tool.subs/idle?])]
+    [element.views/render-to-dom el child-els idle?]))

--- a/src/renderer/element/impl/shape/core.cljs
+++ b/src/renderer/element/impl/shape/core.cljs
@@ -1,7 +1,6 @@
 (ns renderer.element.impl.shape.core
   "https://www.w3.org/TR/SVG/shapes.html#TermShapeElement"
   (:require
-   [re-frame.core :as rf]
    [renderer.element.hierarchy :as element.hierarchy]
    [renderer.element.impl.shape.circle]
    [renderer.element.impl.shape.ellipse]
@@ -12,21 +11,9 @@
    [renderer.element.impl.shape.polygon]
    [renderer.element.impl.shape.polyline]
    [renderer.element.impl.shape.rect]
-   [renderer.element.subs :as-alias element.subs]
-   [renderer.hierarchy :as hierarchy]
-   [renderer.utils.element :as utils.element]))
+   [renderer.hierarchy :as hierarchy]))
 
 (hierarchy/derive! ::element.hierarchy/shape ::element.hierarchy/graphics)
-
-(defmethod element.hierarchy/render-to-string ::element.hierarchy/shape
-  [el]
-  (let [{:keys [tag attrs title children content]} el
-        child-elements @(rf/subscribe [::element.subs/filter-visible children])
-        attrs (->> (utils.element/style->map attrs)
-                   (remove #(empty? (str (second %))))
-                   (into {}))]
-    (into [tag attrs (when title [:title title]) content]
-          (map element.hierarchy/render-to-string child-elements))))
 
 (defmethod element.hierarchy/permitted-content ::element.hierarchy/shape
   [_el]

--- a/src/renderer/utils/element.cljs
+++ b/src/renderer/utils/element.cljs
@@ -2,7 +2,7 @@
   (:require
    ["paper" :refer [Path]]
    ["paperjs-offset" :refer [PaperOffset]]
-   ["style-to-object" :default parse]
+   ["style-to-object" :as parse]
    [clojure.core.matrix :as matrix]
    [clojure.string :as string]
    [clojure.zip :as zip]


### PR DESCRIPTION
We can now add motion paths ([mpath](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/mpath)) to `<animateMotion>` elements by right clicking on an animate motion element, and selecting "Add motion path".  The `<mpath>` element provides the ability to reference an external `<path>` element as the definition of a motion path.

https://github.com/user-attachments/assets/7407f162-3ff5-4092-b9f5-f4867fa0d1e2


Partially handles #82