### PR TITLE
Open document from file association or from a command line argument and prevent multiple app instances

### DIFF
--- a/src/electron/file.cljs
+++ b/src/electron/file.cljs
@@ -28,11 +28,17 @@
         (.then #(-> (select-keys data [:id])
                     (serialize file-path))))))
 
+(defn existing-file?
+  [path]
+  (and (.existsSync fs path)
+       (.isFile (.lstatSync fs path))))
+
 (defn read
   [file-path]
-  (let [data (.readFileSync fs file-path "utf-8")
-        document (edn/read-string data)]
-    (serialize document file-path)))
+  (when (existing-file? file-path)
+    (let [data (.readFileSync fs file-path "utf-8")
+          document (edn/read-string data)]
+      (serialize document file-path))))
 
 (defn show-save-dialog
   [options]

--- a/src/electron/main.cljs
+++ b/src/electron/main.cljs
@@ -47,6 +47,12 @@
     (when (allowed-url? url-parsed)
       (.openExternal shell url-parsed.href))))
 
+(defn open-documents-args
+  [argv]
+  (when (and (> (count argv) 1)
+             (file/existing-file? (last argv)))
+    (file/open (last argv))))
+
 (defn register-ipc-on-events []
   (doseq
    [[e f]
@@ -71,7 +77,8 @@
     [["open-documents" file/open]
      ["save-document" file/save]
      ["save-document-as" file/save-as]
-     ["print" file/show-print-dialog]]]
+     ["print" file/show-print-dialog]
+     ["open-documents-from-args" #(open-documents-args (.-argv js/process))]]]
     (.handle ipcMain e #(f %2))))
 
 (defn register-window-events []
@@ -113,13 +120,6 @@
   (url/format #js {:pathname (.join path js/__dirname s)
                    :protocol "file"}))
 
-(defn open-document-from-args
-  [args]
-  (when (> (count args) 1)
-    (some->> (last args)
-             (file/read)
-             (send-to-renderer "document-opened-from-args"))))
-
 (defn init-main-window! []
   (let [win-state (window-state-keeper #js {:defaultWidth 1920
                                             :defaultHeight 1080})]
@@ -149,8 +149,7 @@
              (.manage win-state ^js @main-window)
              ;; Fixes a bug on linux that blocks unmaximize after load.
              (.restore ^js @main-window)
-             (.initialize log)
-             (open-document-from-args (.-argv js/process))))
+             (.initialize log)))
 
     (.on ^js @main-window "ready-to-show" #(on-ready-to-show @main-window))
 
@@ -193,7 +192,9 @@
         (.on app "ready" init-loading-window!)
         (.on app "second-instance" (fn [_event argv _cwd]
                                      (when (.isMinimized ^js @main-window)
-                                       (.restore ^js @main-window))
+                                       (.restore @main-window))
                                      (.focus @main-window)
-                                     (open-document-from-args argv))))
+                                     (->> (open-documents-args argv)
+                                          (send-to-renderer
+                                           "document-opened-from-args")))))
     (.quit app)))

--- a/src/electron/main.cljs
+++ b/src/electron/main.cljs
@@ -113,6 +113,13 @@
   (url/format #js {:pathname (.join path js/__dirname s)
                    :protocol "file"}))
 
+(defn open-document-from-args
+  [args]
+  (when (> (count args) 1)
+    (some->> (last args)
+             (file/read)
+             (send-to-renderer "document-opened-from-args"))))
+
 (defn init-main-window! []
   (let [win-state (window-state-keeper #js {:defaultWidth 1920
                                             :defaultHeight 1080})]
@@ -142,7 +149,8 @@
              (.manage win-state ^js @main-window)
              ;; Fixes a bug on linux that blocks unmaximize after load.
              (.restore ^js @main-window)
-             (.initialize log)))
+             (.initialize log)
+             (open-document-from-args (.-argv js/process))))
 
     (.on ^js @main-window "ready-to-show" #(on-ready-to-show @main-window))
 
@@ -175,8 +183,17 @@
          "did-finish-load"
          #(.show ^js @loading-window)))
 
+(def lock? (.requestSingleInstanceLock app))
+
 (defn ^:export init! []
-  (sentry-electron-main/init config/sentry)
-  (.on app "window-all-closed" #(when-not (= js/process.platform "darwin")
-                                  (.quit app)))
-  (.on app "ready" init-loading-window!))
+  (if lock?
+    (do (sentry-electron-main/init config/sentry)
+        (.on app "window-all-closed" #(when-not (= js/process.platform "darwin")
+                                        (.quit app)))
+        (.on app "ready" init-loading-window!)
+        (.on app "second-instance" (fn [_event argv _cwd]
+                                     (when (.isMinimized ^js @main-window)
+                                       (.restore ^js @main-window))
+                                     (.focus @main-window)
+                                     (open-document-from-args argv))))
+    (.quit app)))

--- a/src/renderer/app/events.cljs
+++ b/src/renderer/app/events.cljs
@@ -9,10 +9,8 @@
    [renderer.app.effects :as-alias app.effects]
    [renderer.app.events :as-alias app.events]
    [renderer.document.events :as-alias document.events]
-   [renderer.document.handlers :as document.handlers]
    [renderer.effects :as-alias effects]
    [renderer.error.events :as-alias error.events]
-   [renderer.history.handlers :as history.handlers]
    [renderer.i18n.effects :as-alias i18n.effects]
    [renderer.i18n.events :as-alias i18n.events]
    [renderer.input.events :as-alias input.events]
@@ -122,13 +120,10 @@
 
 (rf/reg-event-fx
  ::db-loaded
- [(rf/inject-cofx ::effects/guid)
-  (rf/inject-cofx ::effects/now)]
- (fn [{:keys [db now guid]} _]
-   {:db (if (:active-document db)
-          (snap.handlers/rebuild-tree db)
-          (-> (document.handlers/create db guid)
-              (history.handlers/finalize now [::create-doc "Create document"])))
+ (fn [{:keys [db]} _]
+   {:db (cond-> db
+          (:active-document db)
+          (snap.handlers/rebuild-tree))
     ;; The order of the following events is important.
     ;; Changes require thorough testing on all platforms.
     :fx (into [[:dispatch [::error.events/init-reporting]]
@@ -139,6 +134,7 @@
                [:dispatch [::window.events/update-width]]
                [:dispatch [::i18n.events/set-lang-attrs]]
                [:dispatch [::shell.events/init]]
+               [:dispatch [::document.events/open-from-args]]
                [:dispatch [::set-loading false]]
                [::app.effects/hide-splash-screen]
                ;; We flush to render once so we can get the canvas size.

--- a/src/renderer/app/events.cljs
+++ b/src/renderer/app/events.cljs
@@ -41,7 +41,8 @@
         ["entered-fullscreen" [::window.events/set-fullscreen true]]
         ["leaved-fullscreen" [::window.events/set-fullscreen false]]
         ["minimized" [::window.events/set-minimized true]]
-        ["restored" [::window.events/set-minimized false]]]
+        ["restored" [::window.events/set-minimized false]]
+        ["document-opened-from-args" [::document.events/load-from-args]]]
        (mapv (partial vector ::effects/ipc-on))))
 
 (defn- json->clj

--- a/src/renderer/document/events.cljs
+++ b/src/renderer/document/events.cljs
@@ -160,14 +160,16 @@
  [(rf/inject-cofx ::effects/guid)
   (finalize [::create-doc "Create document"])]
  (fn [{:keys [db guid]} [_]]
-   {:db (document.handlers/create db guid)}))
+   {:db (document.handlers/create db guid)
+    :dispatch ^:flush-dom [::center]}))
 
 (rf/reg-event-fx
  ::new-from-template
  [(rf/inject-cofx ::effects/guid)
   (finalize [::create-doc-from-template "Create document from template"])]
  (fn [{:keys [db guid]} [_ size]]
-   {:db (document.handlers/create db guid size)}))
+   {:db (document.handlers/create db guid size)
+    :dispatch ^:flush-dom [::center]}))
 
 (defn string->edn
   [s]
@@ -189,8 +191,17 @@
        :on-error [::app.events/toast-error]}})))
 
 (rf/reg-event-fx
+ ::open-from-args
+ (fn [_ _]
+   {::effects/ipc-invoke
+    {:channel "open-documents-from-args"
+     :on-success [::load-multiple]
+     :on-error [::app.events/toast-error]
+     :formatter #(mapv string->edn %)}}))
+
+(rf/reg-event-fx
  ::load-from-args
- (fn [_ [_ document]]
+ (fn [_ [_ [document]]]
    {:dispatch [::check-if-open (string->edn document)]}))
 
 (rf/reg-event-fx
@@ -311,7 +322,6 @@
        {:db (cond-> db
               :always
               (-> (document.handlers/create-tab (dissoc document :file-handle))
-                  (document.handlers/center)
                   (document.handlers/add-recent document)
                   (history.handlers/finalize now [::load-doc "Load document"]))
 
@@ -326,7 +336,8 @@
                    db [::document-migrated-description
                        "The document was created with an older version of the
                         app and was migrated to the latest version."])}]])
-             [:dispatch [::persist-file-handle file-handle id]]]}
+             [:dispatch [::persist-file-handle file-handle id]]
+             [:dispatch ^:flush-dom [::center]]]}
        (let [explanation (-> document document.db/explain m.error/humanize str)]
          {::app.effects/toast
           [:error "Invalid document" {:description explanation}]})))))

--- a/src/renderer/document/events.cljs
+++ b/src/renderer/document/events.cljs
@@ -189,6 +189,11 @@
        :on-error [::app.events/toast-error]}})))
 
 (rf/reg-event-fx
+ ::load-from-args
+ (fn [_ [_ document]]
+   {:dispatch [::check-if-open (string->edn document)]}))
+
+(rf/reg-event-fx
  ::open-recent
  (fn [{:keys [db]} [_ {:keys [id path]}]]
    (cond

--- a/src/renderer/effects.cljs
+++ b/src/renderer/effects.cljs
@@ -232,4 +232,4 @@
  ::ipc-on
  (fn [[channel listener]]
    (some-> js/window.api
-           (.on channel #(rf/dispatch listener)))))
+           (.on channel #(rf/dispatch (conj listener %))))))

--- a/test/document_test.cljs
+++ b/test/document_test.cljs
@@ -4,7 +4,6 @@
    [day8.re-frame.test :as rf.test]
    [re-frame.core :as rf]
    [renderer.app.events :as-alias app.events]
-   [renderer.document.db :as document.db]
    [renderer.document.events :as-alias document.events]
    [renderer.document.subs :as-alias document.subs]
    [renderer.element.subs :as-alias element.subs]))
@@ -17,13 +16,13 @@
          active-document (rf/subscribe [::document.subs/active])
          title-bar (rf/subscribe [::document.subs/title-bar])]
      (testing "defaults"
-       (is @document-entities?)
-       (is (document.db/valid? @active-document))
-       (is (= "• Untitled-1 - Repath Studio" @title-bar)))
+       (is (not @document-entities?))
+       (is (not @active-document))
+       (is (= "Repath Studio" @title-bar)))
 
      (testing "create"
        (rf/dispatch [::document.events/new-from-template [800 600]])
-       (is (= "• Untitled-2 - Repath Studio" @title-bar))
+       (is (= "• Untitled-1 - Repath Studio" @title-bar))
        (is (= "800" (->> @(rf/subscribe [::element.subs/entities])
                          (filter #(= (:tag %) :svg))
                          (first)
@@ -37,6 +36,7 @@
    (let [active-document (rf/subscribe [::document.subs/active])
          active-id (rf/subscribe [::document.subs/active-id])]
      (testing "close"
+       (rf/dispatch [::document.events/new])
        (rf/dispatch [::document.events/close @active-id false])
        (is (not @active-document)))
 
@@ -64,6 +64,7 @@
 (deftest save
   (rf.test/run-test-async
    (rf/dispatch-sync [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [active (rf/subscribe [::document.subs/active])
          saved? (rf/subscribe [::document.subs/active-saved?])]
@@ -121,6 +122,7 @@
 (deftest colors
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [fill (rf/subscribe [::document.subs/attr :fill])
          stroke (rf/subscribe [::document.subs/attr :stroke])
@@ -146,6 +148,7 @@
 (deftest elements
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (testing "collapse/expand elements"
      (let [collapsed-ids (rf/subscribe [::document.subs/collapsed-ids])

--- a/test/element_test.cljs
+++ b/test/element_test.cljs
@@ -12,6 +12,7 @@
 (deftest init
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [root (rf/subscribe [::element.subs/root])
          root-children (rf/subscribe [::element.subs/root-children])]
@@ -24,6 +25,7 @@
 (deftest select
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (testing "default state"
@@ -149,6 +151,7 @@
 (deftest visibility
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (rf/dispatch [::element.events/add {:tag :rect
@@ -170,6 +173,7 @@
 (deftest label
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (rf/dispatch [::element.events/add {:tag :rect
@@ -191,6 +195,7 @@
 (deftest lock
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (rf/dispatch [::element.events/add {:tag :rect
@@ -210,6 +215,7 @@
 (deftest attribute
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (rf/dispatch [::element.events/add {:tag :rect
@@ -233,6 +239,7 @@
 (deftest delete
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (rf/dispatch [::element.events/add {:tag :rect
@@ -249,6 +256,7 @@
 (deftest scale
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (rf/dispatch [::element.events/add {:tag :rect
@@ -261,6 +269,7 @@
 (deftest translate
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (rf/dispatch [::element.events/add {:tag :rect
@@ -275,6 +284,7 @@
 (deftest place
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (rf/dispatch [::element.events/add {:tag :rect
@@ -289,6 +299,7 @@
 (deftest ->path
   (rf.test/run-test-async
    (rf/dispatch-sync [::app.events/initialize])
+   (rf/dispatch-sync [::document.events/new])
 
    (rf.test/wait-for
     [::app.events/set-loading false]
@@ -312,6 +323,7 @@
 (deftest stroke->path
   (rf.test/run-test-async
    (rf/dispatch-sync [::app.events/initialize])
+   (rf/dispatch-sync [::document.events/new])
 
    (rf.test/wait-for
     [::app.events/set-loading false]
@@ -336,6 +348,7 @@
 (deftest boolean-operation
   (rf.test/run-test-async
    (rf/dispatch-sync [::app.events/initialize])
+   (rf/dispatch-sync [::document.events/new])
 
    (rf.test/wait-for
     [::app.events/set-loading false]
@@ -365,6 +378,7 @@
 (deftest import-svg
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (rf/dispatch [::element.events/import-svg
@@ -379,6 +393,7 @@
 (deftest animate
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (rf/dispatch [::element.events/add {:tag :rect
                                        :attrs {:x "100"
@@ -394,6 +409,7 @@
 (deftest set-parent
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (rf/dispatch [::element.events/add {:tag :rect
                                        :attrs {:x "100"
@@ -411,6 +427,7 @@
 (deftest group
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (rf/dispatch [::element.events/add {:tag :rect
                                        :attrs {:x "100"
@@ -431,6 +448,7 @@
 (deftest fonts
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
    (rf/dispatch [::app.events/load-system-fonts])
 
    (rf/dispatch [::element.events/add {:tag :text
@@ -448,6 +466,7 @@
 (deftest combine-and-break-apart
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [selected (rf/subscribe [::element.subs/selected])]
      (rf/dispatch [::element.events/add {:tag :path

--- a/test/fixtures.cljs
+++ b/test/fixtures.cljs
@@ -234,6 +234,10 @@
  ::shell.effects/execute
  (fn [_]))
 
+(rf/reg-fx
+ ::effects/ipc-invoke
+ (fn [_]))
+
 (rf/reg-event-db
  ::input.events/keyboard
  (fn [_]))

--- a/test/frame_test.cljs
+++ b/test/frame_test.cljs
@@ -4,6 +4,7 @@
    [day8.re-frame.test :as rf.test]
    [re-frame.core :as rf]
    [renderer.app.events :as-alias app.events]
+   [renderer.document.events :as-alias document.events]
    [renderer.document.subs :as-alias document.subs]
    [renderer.frame.events :as-alias frame.events]
    [renderer.frame.subs :as-alias frame.subs]))
@@ -11,6 +12,7 @@
 (deftest frame
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [viewbox (rf/subscribe [::frame.subs/viewbox])
          zoom (rf/subscribe [::document.subs/zoom])

--- a/test/history_test.cljs
+++ b/test/history_test.cljs
@@ -14,6 +14,7 @@
 (deftest history
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [undos? (rf/subscribe [::history.subs/undos?])
          redos? (rf/subscribe [::history.subs/redos?])

--- a/test/tool_test.cljs
+++ b/test/tool_test.cljs
@@ -4,6 +4,7 @@
    [day8.re-frame.test :as rf.test]
    [re-frame.core :as rf]
    [renderer.app.events :as-alias app.events]
+   [renderer.document.events :as-alias document.events]
    [renderer.element.events :as-alias element.events]
    [renderer.tool.events :as-alias tool.events]
    [renderer.tool.hierarchy :as tool.hierarchy]
@@ -14,6 +15,7 @@
 (deftest tool
   (rf.test/run-test-sync
    (rf/dispatch [::app.events/initialize])
+   (rf/dispatch [::document.events/new])
 
    (let [active-tool (rf/subscribe [::tool.subs/active])]
 


### PR DESCRIPTION
This PR allows opening an `RPS` file by passing it as a first argument on the command line. It also handles opening `RPS` files when the file type association is properly set. If an instance of the app is already running, opening a second instance will be preventing, and if there is a file path passed as an argument, the document will be opened and the running application will be focused. If the file is already open, it will be activated instead. Also, we no longer create a default document when there are no opened documents on initialization.