### PR TITLE
Add history tree labels toggle

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -2,7 +2,7 @@ module.exports = function (config) {
   var junitOutputDir = process.env.CIRCLE_TEST_REPORTS || "target/junit"
 
   config.set({
-    browserDisconnectTimeout: 5000,
+    browserDisconnectTimeout: 10000,
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
         base: 'ChromeHeadless',

--- a/schema-explorer/graph.dot
+++ b/schema-explorer/graph.dot
@@ -45,7 +45,7 @@ digraph {
   "Handle" [label="{Handle|:id [:ref \"HandleId\"]\l:label [:ref \"Translation\"]\l:action [:ref \"HandleAction\"]\l:type [:= :handle]\l:rounded boolean?\l:implied boolean?\l:cursor [:ref \"Cursor\"]\l:position [:ref \"Vec2\"]\l:size number?\l:stroke-width number?\l:parent [:ref \"ElementId\"]\l}", fillcolor="#fff0cd"]
   "HandleAction" [label="{HandleAction|[:enum :translate :scale :edit]\l}", fillcolor="#fff0cd"]
   "HandleId" [label="{HandleId|keyword?\l}", fillcolor="#fff0cd"]
-  "History" [label="{History|:zoom number?\l:translate [:ref \"Vec2\"]\l:position [:ref \"HistoryIndex\"]\l:states [:map-of [:ref \"HistoryIndex\"] [:ref \"HistoryState\"]]\l}", fillcolor="#fff0cd"]
+  "History" [label="{History|:zoom number?\l:labels boolean?\l:translate [:ref \"Vec2\"]\l:position [:ref \"HistoryIndex\"]\l:states [:map-of [:ref \"HistoryIndex\"] [:ref \"HistoryState\"]]\l}", fillcolor="#fff0cd"]
   "HistoryIndex" [label="{HistoryIndex|[:or pos-int? zero?]\l}", fillcolor="#fff0cd"]
   "HistoryState" [label="{HistoryState|:explanation [:ref \"Translation\"]\l:timestamp number?\l:index [:ref \"HistoryIndex\"]\l:elements [:map-of [:ref \"ElementId\"] [:ref \"Element\"]]\l:parent [:ref \"HistoryIndex\"]\l:children [:vector [:ref \"HistoryIndex\"]]\l}", fillcolor="#fff0cd"]
   "Icon" [label="{Icon|:id [:ref \"IconId\"]\l:path [:ref \"IconPath\"]\l}", fillcolor="#fff0cd"]

--- a/src/lang/ar-EG.edn
+++ b/src/lang/ar-EG.edn
@@ -830,7 +830,8 @@
  {:undo "تراجع"
   :redo "إعادة"
   :history "التاريخ"
-  :clear-history "مسح التاريخ"}
+  :clear-history "مسح التاريخ"
+  :labels "التسميات"}
 
  :renderer.menubar.core
  {:menubar "شريط القوائم"

--- a/src/lang/de-DE.edn
+++ b/src/lang/de-DE.edn
@@ -878,7 +878,8 @@
  {:undo "Rückgängig"
   :redo "Wiederholen"
   :history "Verlauf"
-  :clear-history "Verlauf löschen"}
+  :clear-history "Verlauf löschen"
+  :labels "Beschriftungen"}
 
  :renderer.menubar.core
  {:menubar "Menüleiste"

--- a/src/lang/el-GR.edn
+++ b/src/lang/el-GR.edn
@@ -883,7 +883,8 @@
  {:undo "Αναίρεση"
   :redo "Επαναφορά"
   :history "Ιστορικό"
-  :clear-history "Εκκαθάριση ιστορικού"}
+  :clear-history "Εκκαθάριση ιστορικού"
+  :labels "Ετικέτες"}
 
  :renderer.menubar.core
  {:menubar "Γραμμή μενού"

--- a/src/lang/en-US.edn
+++ b/src/lang/en-US.edn
@@ -847,7 +847,8 @@
  {:undo "Undo"
   :redo "Redo"
   :history "History"
-  :clear-history "Clear history"}
+  :clear-history "Clear history"
+  :labels "Labels"}
 
  :renderer.menubar.core
  {:menubar "Menu bar"

--- a/src/lang/es-ES.edn
+++ b/src/lang/es-ES.edn
@@ -866,7 +866,8 @@
  {:undo "Deshacer"
   :redo "Rehacer"
   :history "Historia"
-  :clear-history "Limpiar historial"}
+  :clear-history "Limpiar historial"
+  :labels "Etiquetas"}
 
  :renderer.menubar.core
  {:menubar "Barra de menú"

--- a/src/lang/fr-FR.edn
+++ b/src/lang/fr-FR.edn
@@ -872,7 +872,8 @@
  {:undo "Annuler"
   :redo "Refaire"
   :history "Historique"
-  :clear-history "Effacer l'historique"}
+  :clear-history "Effacer l'historique"
+  :labels "Étiquettes"}
 
  :renderer.menubar.core
  {:menubar "Barre de menu"

--- a/src/lang/it-IT.edn
+++ b/src/lang/it-IT.edn
@@ -875,7 +875,8 @@
  {:undo "Annulla"
   :redo "Ripeti"
   :history "Cronologia"
-  :clear-history "Cancella cronologia"}
+  :clear-history "Cancella cronologia"
+  :labels "Etichette"}
 
  :renderer.menubar.core
  {:menubar "Barra dei menu"

--- a/src/lang/ja-JP.edn
+++ b/src/lang/ja-JP.edn
@@ -815,7 +815,8 @@
  {:undo "元に戻す"
   :redo "やり直し"
   :history "履歴"
-  :clear-history "履歴をクリア"}
+  :clear-history "履歴をクリア"
+  :labels "ラベル"}
 
  :renderer.menubar.core
  {:menubar "メニューバー"

--- a/src/lang/ko-KR.edn
+++ b/src/lang/ko-KR.edn
@@ -809,7 +809,8 @@
  {:undo "실행 취소"
   :redo "다시 실행"
   :history "기록"
-  :clear-history "기록 지우기"}
+  :clear-history "기록 지우기"
+  :labels "라벨"}
 
  :renderer.menubar.core
  {:menubar "메뉴 바"

--- a/src/lang/nl-NL.edn
+++ b/src/lang/nl-NL.edn
@@ -876,7 +876,8 @@
  {:undo "Ongedaan maken"
   :redo "Opnieuw"
   :history "Geschiedenis"
-  :clear-history "Geschiedenis wissen"}
+  :clear-history "Geschiedenis wissen"
+  :labels "Labels"}
 
  :renderer.menubar.core
  {:menubar "Menubalk"

--- a/src/lang/pt-PT.edn
+++ b/src/lang/pt-PT.edn
@@ -858,7 +858,8 @@
  {:undo "Desfazer"
   :redo "Refazer"
   :history "Histórico"
-  :clear-history "Limpar histórico"}
+  :clear-history "Limpar histórico"
+  :labels "Etiquetas"}
 
  :renderer.menubar.core
  {:menubar "Barra de menu"

--- a/src/lang/ru-RU.edn
+++ b/src/lang/ru-RU.edn
@@ -861,7 +861,8 @@
  {:undo "Отменить"
   :redo "Повторить"
   :history "История"
-  :clear-history "Очистить историю"}
+  :clear-history "Очистить историю"
+  :labels "Метки"}
 
  :renderer.menubar.core
  {:menubar "Строка меню"

--- a/src/lang/sv-SE.edn
+++ b/src/lang/sv-SE.edn
@@ -860,7 +860,8 @@
  {:undo "Ångra"
   :redo "Gör om"
   :history "Historik"
-  :clear-history "Rensa historik"}
+  :clear-history "Rensa historik"
+  :labels "Etiketter"}
 
  :renderer.menubar.core
  {:menubar "Menyrad"

--- a/src/lang/tr-TR.edn
+++ b/src/lang/tr-TR.edn
@@ -854,7 +854,8 @@
  {:undo "Geri al"
   :redo "Yinele"
   :history "Geçmiş"
-  :clear-history "Geçmişi temizle"}
+  :clear-history "Geçmişi temizle"
+  :labels "Etiketler"}
 
  :renderer.menubar.core
  {:menubar "Menü çubuğu"

--- a/src/lang/zh-CN.edn
+++ b/src/lang/zh-CN.edn
@@ -769,7 +769,8 @@
  {:undo "撤销"
   :redo "重做"
   :history "历史"
-  :clear-history "清除历史"}
+  :clear-history "清除历史"
+  :labels "标签"}
 
  :renderer.menubar.core
  {:menubar "菜单栏"

--- a/src/renderer/history/core.cljs
+++ b/src/renderer/history/core.cljs
@@ -37,6 +37,13 @@
                        {:confirm-event [::history.events/clear]
                         :confirm-label [::clear-history "Clear history"]}]}])
 
+(rf/dispatch [::action.events/register-action
+              {:id :history/toggle-labels
+               :label [::labels "Labels"]
+               :icon "text"
+               :active [::history.subs/labels?]
+               :event [::history.events/toggle-labels]}])
+
 (rf/dispatch [::action.events/register-action-group
               {:id :edit/history
                :icon "history"

--- a/src/renderer/history/db.cljs
+++ b/src/renderer/history/db.cljs
@@ -18,6 +18,7 @@
 (def History
   [:map {:closed true}
    [:zoom {:optional true} number?]
+   [:labels {:optional true} boolean?]
    [:translate {:optional true} Vec2]
    [:position {:optional true} HistoryIndex]
    [:states {:default {}} [:map-of HistoryIndex HistoryState]]])

--- a/src/renderer/history/events.cljs
+++ b/src/renderer/history/events.cljs
@@ -6,6 +6,11 @@
    [renderer.history.handlers :as history.handlers]))
 
 (rf/reg-event-db
+ ::toggle-labels
+ (fn [db _]
+   (history.handlers/toggle-labels db)))
+
+(rf/reg-event-db
  ::undo
  (fn [db _]
    (history.handlers/undo db)))

--- a/src/renderer/history/handlers.cljs
+++ b/src/renderer/history/handlers.cljs
@@ -184,6 +184,11 @@
   [db]
   (update-in db [:documents (:active-document db)] dissoc :preview-label))
 
+(m/=> toggle-labels [:-> App App])
+(defn toggle-labels
+  [db]
+  (update-in db (path db :labels) not))
+
 (m/=> create-state [:-> App HistoryIndex TimeStamp Translation HistoryState])
 (defn create-state
   [db index timestamp explanation]

--- a/src/renderer/history/subs.cljs
+++ b/src/renderer/history/subs.cljs
@@ -39,6 +39,11 @@
  :-> :zoom)
 
 (rf/reg-sub
+ ::labels?
+ :<- [::history]
+ :-> :labels)
+
+(rf/reg-sub
  ::translate
  :<- [::history]
  :-> :translate)

--- a/src/renderer/history/views.cljs
+++ b/src/renderer/history/views.cljs
@@ -76,21 +76,30 @@
         active? (.-active datum)
         id (.-id datum)
         color (if active? "var(--color-accent)" (.-color datum))
-        title (apply i18n.views/t (.-name datum))]
+        title (apply i18n.views/t (.-name datum))
+        labels? @(rf/subscribe [::history.subs/labels?])]
     (reagent/as-element
-     [:circle.transition-fill
-      {:class "hover:stroke-accent"
-       :on-click #(rf/dispatch [::history.events/go-to id])
-       :on-pointer-enter #(when-not active?
-                            (rf/dispatch [::history.events/preview id]))
-       :on-pointer-leave #(rf/dispatch [::history.events/reset-state id])
-       :cx "0"
-       :cy "0"
-       :stroke color
-       :stroke-width 4
-       :fill color
-       :r 18}
-      [:title title]])))
+     [:g
+      [:circle.transition-fill
+       {:class "hover:stroke-accent"
+        :on-click #(rf/dispatch [::history.events/go-to id])
+        :on-pointer-enter #(when-not active?
+                             (rf/dispatch [::history.events/preview id]))
+        :on-pointer-leave #(rf/dispatch [::history.events/reset-state id])
+        :cx "0"
+        :cy "0"
+        :stroke color
+        :stroke-width 4
+        :fill color
+        :r 18}
+       (when-not labels? [:title title])]
+      (when labels?
+        [:text
+         {:x 32
+          :y 4
+          :fill "var(--color-foreground-default)"
+          :stroke-width "0"}
+         title])])))
 
 (defn on-update
   "https://bkrem.github.io/react-d3-tree/docs/interfaces/TreeProps.html#onupdate"
@@ -109,13 +118,13 @@
                  (.-clientHeight dom-el)] 2)))
 
 (defn tree
-  [ref]
+  [parent-ref]
   (let [tree-data @(rf/subscribe [::history.subs/tree-data])
         zoom @(rf/subscribe [::history.subs/zoom])
-        dom-el (.-current ref)
+        parent (.-current parent-ref)
         [x y] @(rf/subscribe [::history.subs/translate])
-        translate #js {:x (or x (when dom-el (/ (.-clientWidth dom-el) 2)))
-                       :y (or y (when dom-el (/ (.-clientHeight dom-el) 2)))}]
+        translate #js {:x (or x (when parent (/ (.-clientWidth parent) 2)))
+                       :y (or y (when parent (/ (.-clientHeight parent) 2)))}]
     [:> Tree
      {:data tree-data
       :collapsible false
@@ -160,10 +169,10 @@
        {:title (i18n.views/t [::center-view "Center view"])
         :on-click #(rf/dispatch [::history.events/tree-view-updated
                                  0.5 (center ref)])}]
+      [views/action-switch :history/toggle-labels]
       [:div.flex-1]
       (when md? [panel.views/close-button :history])]
      [:div.flex-1
-      {:ref ref
-       :on-pointer-move #(.stopPropagation %)}
+      {:ref ref}
       [tree ref]]
      [legend]]))

--- a/src/renderer/history/views.cljs
+++ b/src/renderer/history/views.cljs
@@ -96,7 +96,8 @@
       (when labels?
         [:text
          {:x 32
-          :y 4
+          :y 5
+          :font-size 10
           :fill "var(--color-foreground-default)"
           :stroke-width "0"}
          title])])))

--- a/src/renderer/history/views.cljs
+++ b/src/renderer/history/views.cljs
@@ -97,7 +97,7 @@
         [:text
          {:x 32
           :y 5
-          :font-size 10
+          :font-size 11
           :fill "var(--color-foreground-default)"
           :stroke-width "0"}
          title])])))


### PR DESCRIPTION
https://github.com/user-attachments/assets/95b71c2a-44e8-4a95-ae0e-4dec7fe33373

The label of each history step used to be displayed when we hover our mouse over the a history tree node. We now have the option to always display the history tree node labels. A cursor state issue when we move our mouse over the tree panel was also fixed.